### PR TITLE
#544: Only create embedded JSON-LD representations when the abstract is longer than 50 characters

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -279,10 +279,9 @@ function externalApiV2() {
       } else if (limit > maxApiLimit) {
         res.status(400).send({ message: `limit must be maximum ${maxApiLimit}`});
         return;
-      } else {
-        bodyQuery.size(limit);
       }
     } else {
+      // Default limit if not provided
       limit = 10;
     }
 
@@ -552,8 +551,10 @@ function jsonProxy() {
       if (!_.isEmpty(json._source)) {
         // If the client requests JSON-LD, return it
         switch (userReq.accepts(["json", "application/ld+json"])) {
-          case "application/ld+json":
-            return getJsonLd(json._source);
+          case "application/ld+json": {
+            const cmmstudy = getStudyModel(json._source,);
+            return getJsonLd(cmmstudy);
+          }
           case "json":
             return json._source;
           default:
@@ -578,7 +579,7 @@ export interface Metadata {
   description: string;
   publisher: string;
   title: string;
-  jsonLd: WithContext<Dataset>;
+  jsonLd: WithContext<Dataset> | undefined;
   id: string;
 }
 
@@ -597,7 +598,7 @@ async function getMetadata(q: string, lang: string | undefined): Promise<Metadat
       description: study.abstractShort,
       title: study.titleStudy,
       publisher: study.publisher.publisher,
-      jsonLd: getJsonLd(study),
+      jsonLd: study.abstract.length >= 50 ? getJsonLd(study) : undefined,
       id: study.id
     };
   } else {

--- a/src/containers/DetailPage.tsx
+++ b/src/containers/DetailPage.tsx
@@ -56,7 +56,8 @@ export class DetailPage extends Component<Props> {
     // Update the JSON-LD representation
     const jsonLDElement = document.getElementById("json-ld");
 
-    if (this.props.item) {
+    // Add JSON-LD metadata if a study is present and has an abstract at least 50 characters long
+    if (this.props.item && this.props.item.abstract.length >= 50) {
       const elementString = '<script id="json-ld" type="application/ld+json">' + JSON.stringify(getJsonLd(this.props.item)) + '</script>';
       if (jsonLDElement) {
         $(jsonLDElement).replaceWith(elementString);

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -4,7 +4,7 @@ export const mockStudy: CMMStudy = {
   id: '1',
   titleStudy: 'Study Title',
   titleStudyHighlight: '',
-  abstract: 'Abstract',
+  abstract: 'This is a mock abstract describing a mock study.\n\nThe key results of this mock study is providing mock data that can be used to validate proper functionality of the application.',
   abstractHighlight: '',
   abstractShort: 'Abstract',
   abstractHighlightShort: '',


### PR DESCRIPTION
Google Dataset Search, as specified at https://developers.google.com/search/docs/appearance/structured-data/dataset, requires the "description" field to be at least 50 characters long. This PR limits the generation of embedded JSON-LD metadata to studies with abstracts longer than 50 characters.

The JSON-LD representation can still be directly requested using API calls.

This closes cessda/cessda.cdc.versions#544.