### PR TITLE
#543: Add lang attribute to top level html element and metadata on front page and detail page

### DIFF
--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html prefix="og: https://ogp.me/ns#">
+<html prefix="og: https://ogp.me/ns#" lang="en">
 <!--
 // Copyright CESSDA ERIC 2017-2023
 //

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -26,6 +26,7 @@ import counterpart from "counterpart";
 
 export interface Props {
   item: CMMStudy;
+  lang: string;
 }
 
 export interface State {
@@ -66,14 +67,14 @@ export default class Detail extends React.Component<Props, State> {
 
   static readonly dateFormatter = DateTimeFormatter.ofPattern("[[dd/]MM/]uuuu");
 
-  static generateElements<T, R>(
+  generateElements<T, R>(
     field: T[],
     element: 'div' | 'tag' | 'ul',
     callback?: (args: T) => R,
     omitLang?: boolean
   ) {
     const elements: JSX.Element[] = [];
-    const lang = counterpart.getLocale();
+    const lang = this.props.lang;
 
     for (let i = 0; i < field.length; i++) {
       if (field[i]) {
@@ -114,29 +115,29 @@ export default class Detail extends React.Component<Props, State> {
    * @param separator the character(s) used for joining the field values
    * @returns <div> element that contains the values separated by the separator
    */
-  static joinValuesBySeparator<T>(arr: Array<T>, extractor: (object: T) => string, separator: string) {
+  joinValuesBySeparator<T>(arr: Array<T>, extractor: (object: T) => string, separator: string) {
     return (
-      <div lang={counterpart.getLocale()}>{arr.map(element => extractor(element)).filter(value => value && value.trim() !== '').join(separator)}</div>
+      <div lang={this.props.lang}>{arr.map(element => extractor(element)).filter(value => value && value.trim() !== '').join(separator)}</div>
     )
   }
 
-  static formatDate(
+  formatDate(
     dateTimeFormatter: DateTimeFormatter,
     date1?: string,
     date2?: string,
     dateFallback?: DataCollectionFreeText[]
   ): JSX.Element | JSX.Element[] {
     if (!date1 && !date2 && !dateFallback) {
-      return <Translate content="language.notAvailable.field" lang={counterpart.getLocale()} />;
+      return <Translate content="language.notAvailable.field" lang={this.props.lang} />;
     }
     if (!date1 && !date2 && dateFallback) {
       if (dateFallback.length === 2 && dateFallback[0].event === 'start' && dateFallback[1].event === 'end') {
         // Handle special case where array items are a start/end date range.
-        return Detail.formatDate(dateTimeFormatter, dateFallback[0].dataCollectionFreeText, dateFallback[1].dataCollectionFreeText);
+        return this.formatDate(dateTimeFormatter, dateFallback[0].dataCollectionFreeText, dateFallback[1].dataCollectionFreeText);
       }
       // Generate elements for each date in the array.
       return (
-          Detail.generateElements(
+          this.generateElements(
             dateFallback,
             'div',
             date => Detail.parseDate(date.dataCollectionFreeText, dateTimeFormatter)
@@ -151,7 +152,7 @@ export default class Detail extends React.Component<Props, State> {
         return <p>{Detail.parseDate(date1, dateTimeFormatter)} - {Detail.parseDate(date2, dateTimeFormatter)}</p>
       }
     } else {
-      return <Translate content="language.notAvailable.field" lang={counterpart.getLocale()} />;
+      return <Translate content="language.notAvailable.field" lang={this.props.lang} />;
     }
   }
 
@@ -181,14 +182,14 @@ export default class Detail extends React.Component<Props, State> {
    * @param universe the universe to format
    * @returns the formatted <p> element
    */
-  private static formatUniverse(universe: Universe) {
-    const inclusion = <p lang={counterpart.getLocale()}>{striptags(universe.inclusion)}</p>;
+  private formatUniverse(universe: Universe) {
+    const inclusion = <p lang={this.props.lang}>{striptags(universe.inclusion)}</p>;
 
     if (universe.exclusion) {
       return (
         <>
           {inclusion}
-          <p lang={counterpart.getLocale()}>Excludes: {striptags(universe.exclusion)}</p>
+          <p lang={this.props.lang}>Excludes: {striptags(universe.exclusion)}</p>
         </>
       );
     } else {
@@ -197,8 +198,7 @@ export default class Detail extends React.Component<Props, State> {
   }
 
   render() {
-    const { item } = this.props;
-    const lang = counterpart.getLocale();
+    const { item, lang } = this.props;
 
     return (
       <article className="w-100">
@@ -221,7 +221,7 @@ Summary information
             component="h2"
             content="metadata.creator"
           />
-          {Detail.generateElements(item.creators, 'div')}
+          {this.generateElements(item.creators, 'div')}
         </section>
 
         <section>
@@ -230,7 +230,7 @@ Summary information
             component="h2"
             content="metadata.studyPersistentIdentifier"
           />
-          {Detail.generateElements(item.pidStudies.filter(p => p.pid), 'div', pidStudy => {
+          {this.generateElements(item.pidStudies.filter(p => p.pid), 'div', pidStudy => {
             // The agency field is an optional attribute, only append if present
             if (pidStudy.agency) {
               return <p>{`${pidStudy.pid} (${pidStudy.agency})`}</p>;
@@ -286,7 +286,7 @@ Summary information
             component="h3"
             content="metadata.dataCollectionPeriod"
           />
-          {Detail.formatDate(
+          {this.formatDate(
             Detail.dateFormatter,
             item.dataCollectionPeriodStartdate,
             item.dataCollectionPeriodEnddate,
@@ -298,35 +298,35 @@ Summary information
             component="h3"
             content="metadata.country"
           />
-          {Detail.joinValuesBySeparator(item.studyAreaCountries, c => c.country, ", ")}
+          {this.joinValuesBySeparator(item.studyAreaCountries, c => c.country, ", ")}
 
           <Translate
             className="data-label"
             component="h3"
             content="metadata.timeDimension"
           />
-          {Detail.generateElements(item.typeOfTimeMethods, 'div', time => time.term)}
+          {this.generateElements(item.typeOfTimeMethods, 'div', time => time.term)}
 
           <Translate
             className="data-label"
             component="h3"
             content="metadata.analysisUnit"
           />
-          {Detail.generateElements(item.unitTypes, 'div', unit => unit.term)}
+          {this.generateElements(item.unitTypes, 'div', unit => unit.term)}
 
           <Translate
             className="data-label"
             component="h3"
             content="metadata.universe"
           />
-          {item.universe ? Detail.formatUniverse(item.universe) : <Translate content="language.notAvailable.field" lang={lang} />}
+          {item.universe ? this.formatUniverse(item.universe) : <Translate content="language.notAvailable.field" lang={lang} />}
 
           <Translate
             className="data-label"
             component="h3"
             content="metadata.samplingProcedure"
           />
-          {Detail.generateElements(item.samplingProcedureFreeTexts, 'div', text => 
+          {this.generateElements(item.samplingProcedureFreeTexts, 'div', text =>
             <div className="data-abstract" dangerouslySetInnerHTML={{__html: text}}/>
           )}
 
@@ -335,7 +335,7 @@ Summary information
             component="h3"
             content="metadata.dataCollectionMethod"
           />
-          {Detail.generateElements(item.typeOfModeOfCollections, 'div', method => method.term)}
+          {this.generateElements(item.typeOfModeOfCollections, 'div', method => method.term)}
         </Panel>
 
         <Panel
@@ -357,14 +357,14 @@ Summary information
             component="h3"
             content="metadata.yearOfPublication"
           />
-          {Detail.formatDate(DateTimeFormatter.ofPattern("uuuu"), item.publicationYear)}
+          {this.formatDate(DateTimeFormatter.ofPattern("uuuu"), item.publicationYear)}
 
           <Translate
             className="data-label"
             component="h3"
             content="metadata.termsOfDataAccess"
           />
-          {Detail.generateElements(item.dataAccessFreeTexts, 'div', text => 
+          {this.generateElements(item.dataAccessFreeTexts, 'div', text =>
             <div className="data-abstract" dangerouslySetInnerHTML={{ __html: text }} />
           )}
         </Panel>
@@ -378,7 +378,7 @@ Summary information
           collapsable={false}
         >
           <div className="tags">
-            {Detail.generateElements(
+            {this.generateElements(
               item.classifications,
               'tag',
               classifications => <Link to={"/?classifications.term[0]=" + encodeURI(classifications.term)}>{upperFirst(classifications.term)}</Link>
@@ -395,7 +395,7 @@ Summary information
           collapsable={false}
         >
           <div className="tags">
-            {Detail.generateElements(this.state.keywordsExpanded ? item.keywords : item.keywords.slice(0, 12), 'tag',
+            {this.generateElements(this.state.keywordsExpanded ? item.keywords : item.keywords.slice(0, 12), 'tag',
               keywords => <Link to={`/?keywords_term=${encodeURI(keywords.term)}`}>{upperFirst(keywords.term)}</Link>
             )}
           </div>
@@ -425,7 +425,7 @@ Summary information
           title={<Translate component="h2" content="metadata.relatedPublications"/>}
           collapsable={false}
         >
-          {Detail.generateElements(item.relatedPublications, 'ul', relatedPublication => {
+          {this.generateElements(item.relatedPublications, 'ul', relatedPublication => {
             const relatedPublicationTitle = striptags(relatedPublication.title);
             if (relatedPublication.holdings?.length > 0) {
               return <a href={relatedPublication.holdings[0]}>{relatedPublicationTitle}</a>;

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -69,19 +69,21 @@ export default class Detail extends React.Component<Props, State> {
   static generateElements<T, R>(
     field: T[],
     element: 'div' | 'tag' | 'ul',
-    callback?: (args: T) => R
+    callback?: (args: T) => R,
+    omitLang?: boolean
   ) {
     const elements: JSX.Element[] = [];
+    const lang = counterpart.getLocale();
 
     for (let i = 0; i < field.length; i++) {
       if (field[i]) {
         const value = callback?.(field[i]) ?? field[i];
         switch(element) {
           case 'tag':
-            elements.push(<span className="tag" key={i}>{value}</span>);
+            elements.push(<span className="tag" lang={omitLang ? undefined : lang} key={i}>{value}</span>);
             break;
           case 'div':
-            elements.push(<div key={i}>{value}</div>);
+            elements.push(<div lang={omitLang ? undefined : lang} key={i}>{value}</div>);
             break;
           case 'ul':
             elements.push(<li key={i}>{value}</li>)
@@ -90,12 +92,12 @@ export default class Detail extends React.Component<Props, State> {
     }
 
     if (elements.length === 0) {
-      return <Translate content="language.notAvailable.field" />;
+      return <Translate content="language.notAvailable.field" lang={lang} />;
     }
 
     if (element === 'ul') {
       return (
-        <ul>
+        <ul lang={omitLang ? undefined : lang}>
           {elements}
         </ul>
       );
@@ -114,7 +116,7 @@ export default class Detail extends React.Component<Props, State> {
    */
   static joinValuesBySeparator<T>(arr: Array<T>, extractor: (object: T) => string, separator: string) {
     return (
-      <div>{arr.map(element => extractor(element)).filter(value => value && value.trim() !== '').join(separator)}</div>
+      <div lang={counterpart.getLocale()}>{arr.map(element => extractor(element)).filter(value => value && value.trim() !== '').join(separator)}</div>
     )
   }
 
@@ -125,7 +127,7 @@ export default class Detail extends React.Component<Props, State> {
     dateFallback?: DataCollectionFreeText[]
   ): JSX.Element | JSX.Element[] {
     if (!date1 && !date2 && !dateFallback) {
-      return <Translate content="language.notAvailable.field" />;
+      return <Translate content="language.notAvailable.field" lang={counterpart.getLocale()} />;
     }
     if (!date1 && !date2 && dateFallback) {
       if (dateFallback.length === 2 && dateFallback[0].event === 'start' && dateFallback[1].event === 'end') {
@@ -149,7 +151,7 @@ export default class Detail extends React.Component<Props, State> {
         return <p>{Detail.parseDate(date1, dateTimeFormatter)} - {Detail.parseDate(date2, dateTimeFormatter)}</p>
       }
     } else {
-      return <Translate content="language.notAvailable.field" />;
+      return <Translate content="language.notAvailable.field" lang={counterpart.getLocale()} />;
     }
   }
 
@@ -180,13 +182,13 @@ export default class Detail extends React.Component<Props, State> {
    * @returns the formatted <p> element
    */
   private static formatUniverse(universe: Universe) {
-    const inclusion = <p>{striptags(universe.inclusion)}</p>;
+    const inclusion = <p lang={counterpart.getLocale()}>{striptags(universe.inclusion)}</p>;
 
     if (universe.exclusion) {
       return (
         <>
           {inclusion}
-          <p>Excludes: {striptags(universe.exclusion)}</p>
+          <p lang={counterpart.getLocale()}>Excludes: {striptags(universe.exclusion)}</p>
         </>
       );
     } else {
@@ -196,6 +198,7 @@ export default class Detail extends React.Component<Props, State> {
 
   render() {
     const { item } = this.props;
+    const lang = counterpart.getLocale();
 
     return (
       <article className="w-100">
@@ -208,8 +211,8 @@ Summary information
           content="metadata.studyTitle"
         />
 
-        <p>
-          {item.titleStudy || <Translate content="language.notAvailable.field" />}
+        <p lang={lang}>
+          {item.titleStudy || <Translate content="language.notAvailable.field"/>}
         </p>
 
         <section>
@@ -234,7 +237,7 @@ Summary information
             }
 
             return <p>{pidStudy.pid}</p>;
-          })}
+          }, true)}
         </section>
 
         <section>
@@ -244,9 +247,9 @@ Summary information
             content="metadata.abstract"
           />
           {this.state.abstractExpanded ?
-            <div className="data-abstract" dangerouslySetInnerHTML={{ __html: item.abstract }}/>
+            <div className="data-abstract" lang={lang} dangerouslySetInnerHTML={{ __html: item.abstract }}/>
           :
-            <div className="data-abstract">{truncate(striptags(item.abstract), { length: Detail.truncatedAbstractLength, separator: ' ' })}</div>
+            <div className="data-abstract" lang={lang}>{truncate(striptags(item.abstract), { length: Detail.truncatedAbstractLength, separator: ' ' })}</div>
           }
           {item.abstract.length > Detail.truncatedAbstractLength &&
             <a className="button is-small is-white" onClick={() => {
@@ -316,7 +319,7 @@ Summary information
             component="h3"
             content="metadata.universe"
           />
-          {item.universe ? Detail.formatUniverse(item.universe) : <Translate content="language.notAvailable.field" />}
+          {item.universe ? Detail.formatUniverse(item.universe) : <Translate content="language.notAvailable.field" lang={lang} />}
 
           <Translate
             className="data-label"
@@ -345,7 +348,7 @@ Summary information
             component="h3"
             content="metadata.publisher"
           />
-          <p>
+          <p lang={lang}>
             {item.publisher ? item.publisher.publisher : <Translate content="language.notAvailable.field" />}
           </p>
 
@@ -429,7 +432,7 @@ Summary information
             } else {
               return relatedPublicationTitle;
             }
-          })}
+          }, true)}
         </Panel>
       </article>
     );

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -95,7 +95,7 @@ export class Result extends Component<Props, ComponentState> {
 	
     return (
       <div className="list_hit" data-qa="hit">
-        <h4 className={bemBlocks.item().mix(bemBlocks.container('hith4'))}>
+        <h4 className={bemBlocks.item().mix(bemBlocks.container('hith4'))} lang={currentLanguage}>
           <Link to={{
             pathname: "/detail",
             query: {
@@ -104,10 +104,10 @@ export class Result extends Component<Props, ComponentState> {
             }
           }}><span dangerouslySetInnerHTML={{__html: item.titleStudyHighlight || item.titleStudy}}></span></Link>
         </h4>
-        <div className={bemBlocks.item().mix(bemBlocks.container('meta'))}>
+        <div className={bemBlocks.item().mix(bemBlocks.container('meta'))} lang={currentLanguage}>
           {creators}
         </div>
-        <div className={bemBlocks.item().mix(bemBlocks.container('desc'))}>
+        <div className={bemBlocks.item().mix(bemBlocks.container('desc'))} lang={currentLanguage}>
           {this.state.abstractExpanded ? 
             <span className="abstr" dangerouslySetInnerHTML={{__html: item.abstractHighlight || item.abstract}}/>
           :

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -18,7 +18,6 @@ import type {State} from '../types';
 import {push} from 'react-router-redux';
 import Translate from 'react-translate-component';
 import { Link } from 'react-router';
-import counterpart from 'counterpart';
 
 export type Props = ReturnType<typeof mapDispatchToProps> & ReturnType<typeof mapStateToProps>
 
@@ -26,14 +25,15 @@ export class Similars extends Component<Props> {
 
   render() {
     const {
-      similars    
+      similars,
+      currentLanguage
     } = this.props;
 
     const links: JSX.Element[] = [];
 
     for (let i = 0; i < similars.length; i++) {
       // Construct the similar URL
-      links.push(<p lang={counterpart.getLocale()}><Link key={i} to={{
+      links.push(<p lang={currentLanguage}><Link key={i} to={{
         pathname: '/detail',
         query: { q: similars[i].id }
       }}>{similars[i].title}</Link></p>);
@@ -50,9 +50,10 @@ export class Similars extends Component<Props> {
   }
 }
 
-export function mapStateToProps(state: Pick<State, "detail">) {
+export function mapStateToProps(state: Pick<State, "detail" | "language">) {
   return {
-    similars: state.detail.similars
+    similars: state.detail.similars,
+    currentLanguage: state.language.currentLanguage.code
   };
 }
 

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -33,14 +33,14 @@ export class Similars extends Component<Props> {
 
     for (let i = 0; i < similars.length; i++) {
       // Construct the similar URL
-      links.push(<Link key={i} to={{
+      links.push(<p lang={counterpart.getLocale()}><Link key={i} to={{
         pathname: '/detail',
         query: { q: similars[i].id }
-      }}>{similars[i].title}</Link>);
+      }}>{similars[i].title}</Link></p>);
     }
 
     return (
-      <div className="similars" lang={counterpart.getLocale()}>
+      <div className="similars">
         {links}
         {links.length === 0 &&
          <Translate component="p" content="similarResults.notAvailable"/>

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -18,6 +18,7 @@ import type {State} from '../types';
 import {push} from 'react-router-redux';
 import Translate from 'react-translate-component';
 import { Link } from 'react-router';
+import counterpart from 'counterpart';
 
 export type Props = ReturnType<typeof mapDispatchToProps> & ReturnType<typeof mapStateToProps>
 
@@ -39,7 +40,7 @@ export class Similars extends Component<Props> {
     }
 
     return (
-      <div className="similars">
+      <div className="similars" lang={counterpart.getLocale()}>
         {links}
         {links.length === 0 &&
          <Translate component="p" content="similarResults.notAvailable"/>

--- a/src/containers/DetailPage.tsx
+++ b/src/containers/DetailPage.tsx
@@ -153,7 +153,7 @@ export class DetailPage extends Component<Props> {
         
                   <div className="is-clearfix"/>
                 </div>
-                <Detail item={item}/>
+                <Detail item={item} lang={currentLanguage.code}/>
               </>
             :
               <div className="panel pt-15">

--- a/src/containers/DetailPage.tsx
+++ b/src/containers/DetailPage.tsx
@@ -157,10 +157,10 @@ export class DetailPage extends Component<Props> {
               </>
             :
               <div className="panel pt-15">
-                <p className="fs-14 mb-15">
+                <p className="fs-14 mb-15" lang={currentLanguage.code}>
                   <Translate component="strong" content="language.notAvailable.heading"/>
                 </p>
-                <Translate className="fs-14 mb-15" component="p" content="language.notAvailable.content"/>
+                <Translate className="fs-14 mb-15" component="p" content="language.notAvailable.content" lang={currentLanguage.code}/>
                 {this.props.availableLanguages.length > 0 &&
                   <p className="fs-14 mb-15"><Translate content="language.notAvailable.alternateLanguage"/>: {languageLinks}</p>
                 }

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -96,7 +96,7 @@ describe('Detail component', () => {
                                              {"country": "Norway"}, {"country": "Sweden"},
                                              {"country": " "}],
                                              c => c.country, ", ")}</>).html()
-    ).toContain('<div>Finland, Norway, Sweden</div>');
+    ).toContain('<div lang="en">Finland, Norway, Sweden</div>');
   });
 
   it('should handle formatting dates with missing data', () => {

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -23,13 +23,16 @@ function setup(item?: Partial<CMMStudy>) {
     item: {
       ...mockStudy,
       ...item
-    }
+    },
+    lang: "en"
   };
 
   const enzymeWrapper = shallow(<Detail {...props} />);
+  const detailInstance = enzymeWrapper.instance() as Detail;
   return {
     props,
-    enzymeWrapper
+    enzymeWrapper,
+    detailInstance
   };
 }
 
@@ -84,15 +87,17 @@ describe('Detail component', () => {
   });
 
   it('should handle generating elements with no value', () => {
+    const { detailInstance } = setup();
     // "" is a falsy value, so should be dropped.
     expect(
-      mount(<>{Detail.generateElements([""], "div", e => e)}</>).html()
+      mount(<>{detailInstance.generateElements([""], "div", e => e)}</>).html()
     ).toContain('notAvailable');
   });
 
   it('should handle joining values and returning them in div even if some have no value', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.joinValuesBySeparator([{"country": "Finland"}, {"country": ""},
+      mount(<>{detailInstance.joinValuesBySeparator([{"country": "Finland"}, {"country": ""},
                                              {"country": "Norway"}, {"country": "Sweden"},
                                              {"country": " "}],
                                              c => c.country, ", ")}</>).html()
@@ -100,15 +105,17 @@ describe('Detail component', () => {
   });
 
   it('should handle formatting dates with missing data', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.formatDate(Detail.dateFormatter)}</>).html()
+      mount(<>{detailInstance.formatDate(Detail.dateFormatter)}</>).html()
     ).toContain('notAvailable');
   });
 
   it('should handle special case where array items are a start/end date range', () => {
+    const { detailInstance } = setup();
     expect(
       mount(<>{
-        Detail.formatDate(
+        detailInstance.formatDate(
           Detail.dateFormatter,
           undefined,
           undefined,
@@ -130,9 +137,10 @@ describe('Detail component', () => {
   });
 
   it('should handle formatting dates with fallback array containing date range', () => {
+    const { detailInstance } = setup();
     expect(
       mount(<>{
-        Detail.formatDate(
+        detailInstance.formatDate(
           Detail.dateFormatter,
           undefined,
           undefined,
@@ -155,32 +163,36 @@ describe('Detail component', () => {
   });
 
   it('should handle formatting dates with invalid first date', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.formatDate(Detail.dateFormatter, 'Not a date')}</>)
+      mount(<>{detailInstance.formatDate(Detail.dateFormatter, 'Not a date')}</>)
         .find('p')
         .text()
     ).toBe('Not a date');
   });
 
   it('should handle formatting dates as a range with invalid first date', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.formatDate(Detail.dateFormatter, 'Not a date', '2006-05-04')}</>)
+      mount(<>{detailInstance.formatDate(Detail.dateFormatter, 'Not a date', '2006-05-04')}</>)
         .find('p')
         .text()
     ).toBe('Not a date - 04/05/2006');
   });
 
   it('should handle formatting dates as a range with valid second date', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.formatDate(Detail.dateFormatter, '2003-02-01', '2006-05-04')}</>)
+      mount(<>{detailInstance.formatDate(Detail.dateFormatter, '2003-02-01', '2006-05-04')}</>)
         .find('p')
         .text()
     ).toBe('01/02/2003 - 04/05/2006');
   });
 
   it('should handle formatting dates as a range with invalid second date', () => {
+    const { detailInstance } = setup();
     expect(
-      mount(<>{Detail.formatDate(Detail.dateFormatter, '2003-02-01', 'Not a date')}</>)
+      mount(<>{detailInstance.formatDate(Detail.dateFormatter, '2003-02-01', 'Not a date')}</>)
         .find('p')
         .text()
     ).toBe('01/02/2003 - Not a date');

--- a/tests/src/components/Similars.tsx
+++ b/tests/src/components/Similars.tsx
@@ -17,6 +17,7 @@ import { shallow } from 'enzyme';
 import { mapDispatchToProps, mapStateToProps, Props, Similars } from '../../../src/components/Similars';
 import searchkit from '../../../src/utilities/searchkit';
 import { mockStudy } from '../../common/mockdata';
+import { Language, languages } from '../../../src/utilities/language';
 
 // Mock props and shallow render component for test.
 function setup(partialProps?: Partial<Props>) {
@@ -31,6 +32,7 @@ function setup(partialProps?: Partial<Props>) {
         title: 'Similar Study Title 2'
       }
     ],
+    currentLanguage: "en",
     push: jest.fn(),
     ...partialProps 
   };
@@ -73,11 +75,16 @@ describe('Similars component', () => {
         detail: {
           languageAvailableIn: [],
           study: mockStudy,
-          similars: props.similars
-        }
+          similars: props.similars,
+        },
+        language: {
+          currentLanguage: languages.find(lang => lang.code === props.currentLanguage) as Language,
+          list: languages
+        },
       })
     ).toEqual({
-      similars: props.similars
+      similars: props.similars,
+      currentLanguage: props.currentLanguage
     });
   });
 


### PR DESCRIPTION
All metadata fields on Detail page have lang attribute except for PID, data collection period, publication year and related publications. Related publications should have lang for each publication but that would require knowing their language and that is a bit out of scope for this issue.

Lang attributes for translations added only for the three that actually have a translation in every language.