### PR TITLE
532 include sorting options of cdc interface to searchapi

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -270,24 +270,29 @@ function externalApiV2() {
     const bodyQuery = bodybuilder();
 
     //Implementing Sorting Options
-    if (sortBy){
-      if (sortBy=="titleAscending")
+    switch (sortBy) {
+      case undefined: //if no sorting option is provided, sort by default Relevance - as UI
+        bodyQuery.sort('_score', 'desc');
+        break;
+      case "titleAscending":
         bodyQuery.sort('titleStudy.raw', 'asc');
-      else if (sortBy=="titleDescending")
+        break;
+      case "titleDescending":
         bodyQuery.sort('titleStudy.raw', 'desc');
-      else if (sortBy=="dateOfCollectionOldest")
+        break;
+      case "dateOfCollectionOldest":
         bodyQuery.sort('dataCollectionPeriodEnddate', 'asc');
-      else if (sortBy=="dateOfCollectionNewest")
+        break;
+      case "dateOfCollectionNewest":
         bodyQuery.sort('dataCollectionPeriodEnddate', 'desc');
-      else if (sortBy=="dateOfPublicationNewest")
+        break;
+      case "dateOfPublicationNewest":
         bodyQuery.sort('publicationYear', 'desc');
-      else{
+        break;
+      default:
         res.status(400).send({ message: 'Please provide a proper sorting option. Available: titleAscending, titleDescending, dateOfCollectionOldest, dateOfCollectionNewest, dateOfPublicationNewest'});
         return;
-      }
     }
-    else //if no sorting option is provided, sort by default Relevance - as UI
-    bodyQuery.sort('_score', 'desc');
 
     // Validate the limit parameter
     let limit: number;


### PR DESCRIPTION
This seems to be stable.

Sorting Options: 

- Relevance (Default)
- titleAscending
- titleDescending
- dateOfCollectionOldest
- dateOfCollectionNewest
- dateOfPublicationNewest

Sorting is a non mandatory parameter. If no option is provided with the API call, as in the CDC UI, results sort by default (Relevance).

If any other sorting option is provided, API will return status code 400 with message "Please provide a proper sorting option. Available: titleAscending, titleDescending, dateOfCollectionOldest, dateOfCollectionNewest, dateOfPublicationNewest"