### PR TITLE
#561: Change keywords filter to be similar to topic filter, update Topic filter tooltip text, fix key in Similars

### DIFF
--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -299,7 +299,7 @@ Summary information
         >
           <div className="tags">
             {this.generateElements(this.state.keywordsExpanded ? item.keywords : item.keywords.slice(0, 12), 'tag',
-              keywords => <Link to={`/?keywords_term=${encodeURI(keywords.term)}`}>{upperFirst(keywords.term)}</Link>
+              keywords => <Link to={`/?keywords.term[0]=${encodeURI(keywords.term)}`}>{upperFirst(keywords.term)}</Link>
             )}
           </div>
           {item.keywords.length > Detail.truncatedKeywordsLength &&

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -33,7 +33,7 @@ export class Similars extends Component<Props> {
 
     for (let i = 0; i < similars.length; i++) {
       // Construct the similar URL
-      links.push(<p lang={currentLanguage}><Link key={i} to={{
+      links.push(<p key={similars[i].id} lang={currentLanguage}><Link to={{
         pathname: '/detail',
         query: { q: similars[i].id }
       }}>{similars[i].title}</Link></p>);

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -33,7 +33,7 @@ export class Similars extends Component<Props> {
 
     for (let i = 0; i < similars.length; i++) {
       // Construct the similar URL
-      links.push(<p key={similars[i].id} lang={currentLanguage}><Link to={{
+      links.push(<p key={i} lang={currentLanguage}><Link to={{
         pathname: '/detail',
         query: { q: similars[i].id }
       }}>{similars[i].title}</Link></p>);

--- a/src/components/Similars.tsx
+++ b/src/components/Similars.tsx
@@ -33,7 +33,7 @@ export class Similars extends Component<Props> {
 
     for (let i = 0; i < similars.length; i++) {
       // Construct the similar URL
-      links.push(<p key={i} lang={currentLanguage}><Link to={{
+      links.push(<p key={similars[i].id} lang={currentLanguage}><Link to={{
         pathname: '/detail',
         query: { q: similars[i].id }
       }}>{similars[i].title}</Link></p>);

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -19,7 +19,7 @@ import TopBar from '../components/Topbar';
 import Pagination from '../components/Pagination';
 import {
   Hits, Layout, LayoutBody, LayoutResults, NoHits, Pagination as SearchkitPagination, RangeFilter, RangeSliderInput,
-  RefinementListFilter, SearchkitProvider, SideBar, FacetAccessor
+  RefinementListFilter, SearchkitProvider, SideBar
 } from 'searchkit';
 import Translate from 'react-translate-component';
 import Header from '../components/Header';
@@ -32,21 +32,12 @@ import $ from 'jquery';
 import type {State} from '../types';
 import counterpart from 'counterpart';
 
-type FacetsPerPage = {
-  [key: string]: number;
-};
-
 export type Props = ReturnType<typeof mapStateToProps>;
 
 export class SearchPage extends Component<Props> {
 
-  facetsPerPage: FacetsPerPage = {
-    'keywords.term': 100000
-  }
-
   componentDidMount() {
     this.updateTitle();
-    this.changeFacetsPerPage();
     searchkit.resetState();
 
     // Remove the JSON-LD representation if present
@@ -72,15 +63,6 @@ export class SearchPage extends Component<Props> {
     } else {
       document.title = counterpart.translate('datacatalogue');
     }
-  }
-
-  changeFacetsPerPage() {
-    // Change the default (50) facetsPerPage if it has been defined for the filter
-    searchkit.getAccessorsByType(FacetAccessor).forEach((facet: FacetAccessor) => {
-      if (this.facetsPerPage[facet.key]) {
-        facet.options.facetsPerPage = this.facetsPerPage[facet.key]
-      }
-    });
   }
 
   autoExpandFilter(filterName: string): void {
@@ -143,7 +125,7 @@ export class SearchPage extends Component<Props> {
                                       containerComponent={<Panel
                                         title={<Translate content='filters.keywords.label'/>}
                                         tooltip={<Tooltip id="filters-keywords-tooltip"
-                                                          content={<Translate content='filters.keywords.tooltip.content' unsafe/>}
+                                                          content={<Translate content='filters.keywords.tooltip.content' size='2000' unsafe/>}
                                                           ariaLabel={counterpart.translate("filters.keywords.tooltip.ariaLabel")}/>}
                                         className="keywords"
                                         collapsable={true}
@@ -152,35 +134,7 @@ export class SearchPage extends Component<Props> {
                                       listComponent={<MultiSelect placeholder={<Translate content='filters.keywords.placeholder'/>}
                                                                   ariaLabel={counterpart.translate('filters.keywords.label')}/>}
                                       size={2000}
-                                      showMore={true}
-                                      translations={{
-                                        'facets.view_more': counterpart.translate('filters.view.more', {
-                                                                                  name: 'keywords',
-                                                                                  facetsPerPage: this.facetsPerPage["keywords.term"]
-                                        }),
-                                        'facets.view_less': counterpart.translate('filters.view.less', {
-                                                                                  name: 'keywords',
-                                                                                  defaultSize: 2000
-                                        }),
-                                        'facets.view_all': counterpart.translate('filters.view.all', {
-                                                                                 name: 'keywords'
-                                        })
-                                      }}/>
-
-                {/* <InputFilter id="keywords_term"
-                              title={counterpart.translate('filters.keywords.label')}
-                              searchOnChange={false}
-                              placeholder={counterpart.translate('filters.keywords.placeholder')}
-                              containerComponent={<Panel
-                                title={<Translate content='filters.keywords.label'/>}
-                                tooltip={<Tooltip id="filters-keywords-tooltip"
-                                                  content={<Translate content='filters.keywords.tooltip.content' unsafe/>}
-                                                  ariaLabel={counterpart.translate("filters.keywords.tooltip.ariaLabel")}/>}
-                                className="keywords"
-                                collapsable={true}
-                                defaultCollapsed={true}/>
-                              }
-                              queryFields={["keywordsSearchField"]}/> */}
+                                      showMore={false}/>
 
                 <RangeFilter min={1900}
                             max={new Date().getFullYear()}

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -18,8 +18,8 @@ import Footer from '../components/Footer';
 import TopBar from '../components/Topbar';
 import Pagination from '../components/Pagination';
 import {
-  Hits, InputFilter, Layout, LayoutBody, LayoutResults, NoHits, Pagination as SearchkitPagination, RangeFilter, RangeSliderInput,
-  RefinementListFilter, SearchkitProvider, SideBar
+  Hits, Layout, LayoutBody, LayoutResults, NoHits, Pagination as SearchkitPagination, RangeFilter, RangeSliderInput,
+  RefinementListFilter, SearchkitProvider, SideBar, FacetAccessor
 } from 'searchkit';
 import Translate from 'react-translate-component';
 import Header from '../components/Header';
@@ -32,12 +32,21 @@ import $ from 'jquery';
 import type {State} from '../types';
 import counterpart from 'counterpart';
 
+type FacetsPerPage = {
+  [key: string]: number;
+};
+
 export type Props = ReturnType<typeof mapStateToProps>;
 
 export class SearchPage extends Component<Props> {
 
+  facetsPerPage: FacetsPerPage = {
+    'keywords.term': 100000
+  }
+
   componentDidMount() {
     this.updateTitle();
+    this.changeFacetsPerPage();
     searchkit.resetState();
 
     // Remove the JSON-LD representation if present
@@ -49,10 +58,9 @@ export class SearchPage extends Component<Props> {
 
   componentDidUpdate(): void {
     // Auto expand filters if they contain selected values.
-    this.autoExpandFilter('classifications.term');
-    this.autoExpandFilter('dataCollectionYear');
-    this.autoExpandFilter('studyAreaCountries.searchField');
-    this.autoExpandFilter('publisher.publisher');
+    for (let filterName in this.props.filters) {
+      this.autoExpandFilter(filterName);
+    }
 
     // Set the page title
     this.updateTitle();
@@ -66,10 +74,26 @@ export class SearchPage extends Component<Props> {
     }
   }
 
+  changeFacetsPerPage() {
+    // Change the default (50) facetsPerPage if it has been defined for the filter
+    searchkit.getAccessorsByType(FacetAccessor).forEach((facet: FacetAccessor) => {
+      if (this.facetsPerPage[facet.key]) {
+        facet.options.facetsPerPage = this.facetsPerPage[facet.key]
+      }
+    });
+  }
+
   autoExpandFilter(filterName: string): void {
     const filter = $(`.filter--${filterName.replace('.', '\\.')} > .is-collapsed`);
-    if (!filter.data('expanded') && !_.isEmpty(this.props.filters[filterName])) {
-      filter.data('expanded', true).trigger("click");
+    const filterValue = this.props.filters[filterName];
+    if (typeof filterValue === 'string'){
+      if (!filter.data('expanded') && typeof filterValue !== 'undefined' && filterValue.trim() !== "") {
+        filter.data('expanded', true).trigger("click");
+      }
+    } else {
+      if (!filter.data('expanded') && !_.isEmpty(filterValue)) {
+        filter.data('expanded', true).trigger("click");
+      }
     }
   }
 
@@ -77,6 +101,7 @@ export class SearchPage extends Component<Props> {
     const {
       showMobileFilters
     } = this.props;
+
     return (
       <SearchkitProvider searchkit={searchkit}>
         <Layout className={showMobileFilters ? 'show-mobile-filters' : ''}>
@@ -95,43 +120,67 @@ export class SearchPage extends Component<Props> {
                                       orderKey="_count"
                                       orderDirection="desc"
                                       operator="OR"
-                                      containerComponent={<Panel title={<Translate content='filters.topic.label'/>}
-                                                                tooltip={<Tooltip id="filters-topic-tooltip"
-                                                                                  content={<Translate content='filters.topic.tooltip.content' unsafe/>}
-                                                                                  ariaLabel={counterpart.translate("filters.topic.tooltip.ariaLabel")}/>}
-                                                                className="classifications"
-                                                                collapsable={true}
-                                                                defaultCollapsed={true}/>}
+                                      containerComponent={<Panel
+                                        title={<Translate content='filters.topic.label'/>}
+                                        tooltip={<Tooltip id="filters-topic-tooltip"
+                                                          content={<Translate content='filters.topic.tooltip.content' unsafe/>}
+                                                          ariaLabel={counterpart.translate("filters.topic.tooltip.ariaLabel")}/>}
+                                        className="classifications"
+                                        collapsable={true}
+                                        defaultCollapsed={true}/>
+                                      }
                                       listComponent={<MultiSelect placeholder={<Translate content='filters.topic.placeholder'/>}
                                                                   ariaLabel={counterpart.translate('filters.topic.label')}/>}
-                                      size={100}/>
+                                      size={2000}
+                                      showMore={false}/>
 
-                {/* <RefinementListFilter id="keywords.term"
-                                      title={counterpart.translate('filters.topic.label')}
-                                      field={'keywordsSearchField'}
-                                      orderKey="_key"
-                                      orderDirection="asc"
+                <RefinementListFilter id="keywords.term"
+                                      title={counterpart.translate('filters.keywords.label')}
+                                      field={'keywordsKeywordField'}
+                                      orderKey="_count"
+                                      orderDirection="desc"
                                       operator="OR"
-                                      containerComponent={<Panel title={<Translate content='filters.topic.label'/>}
-                                                                tooltip={<Translate content="filters.topic.tooltip" unsafe/>}
-                                                                className="keywords"
-                                                                collapsable={true}
-                                                                defaultCollapsed={true}/>}
-                                      listComponent={<MultiSelect placeholder={<Translate content='filters.topic.placeholder'/>}/>}
-                                      size={2700}/> */}
+                                      containerComponent={<Panel
+                                        title={<Translate content='filters.keywords.label'/>}
+                                        tooltip={<Tooltip id="filters-keywords-tooltip"
+                                                          content={<Translate content='filters.keywords.tooltip.content' unsafe/>}
+                                                          ariaLabel={counterpart.translate("filters.keywords.tooltip.ariaLabel")}/>}
+                                        className="keywords"
+                                        collapsable={true}
+                                        defaultCollapsed={true}/>
+                                      }
+                                      listComponent={<MultiSelect placeholder={<Translate content='filters.keywords.placeholder'/>}
+                                                                  ariaLabel={counterpart.translate('filters.keywords.label')}/>}
+                                      size={2000}
+                                      showMore={true}
+                                      translations={{
+                                        'facets.view_more': counterpart.translate('filters.view.more', {
+                                                                                  name: 'keywords',
+                                                                                  facetsPerPage: this.facetsPerPage["keywords.term"]
+                                        }),
+                                        'facets.view_less': counterpart.translate('filters.view.less', {
+                                                                                  name: 'keywords',
+                                                                                  defaultSize: 2000
+                                        }),
+                                        'facets.view_all': counterpart.translate('filters.view.all', {
+                                                                                 name: 'keywords'
+                                        })
+                                      }}/>
 
-                <InputFilter id="keywords.term"
+                {/* <InputFilter id="keywords_term"
                               title={counterpart.translate('filters.keywords.label')}
                               searchOnChange={false}
                               placeholder={counterpart.translate('filters.keywords.placeholder')}
-                              containerComponent={<Panel title={<Translate content='filters.keywords.label'/>}
-                                                        tooltip={<Tooltip id="filters-keywords-tooltip"
-                                                                          content={<Translate content='filters.keywords.tooltip.content' unsafe/>}
-                                                                          ariaLabel={counterpart.translate("filters.keywords.tooltip.ariaLabel")}/>}
-                                                        className="keywords"
-                                                        collapsable={true}
-                                                        defaultCollapsed={true}/>}
-                              queryFields={["keywordsSearchField"]}/>
+                              containerComponent={<Panel
+                                title={<Translate content='filters.keywords.label'/>}
+                                tooltip={<Tooltip id="filters-keywords-tooltip"
+                                                  content={<Translate content='filters.keywords.tooltip.content' unsafe/>}
+                                                  ariaLabel={counterpart.translate("filters.keywords.tooltip.ariaLabel")}/>}
+                                className="keywords"
+                                collapsable={true}
+                                defaultCollapsed={true}/>
+                              }
+                              queryFields={["keywordsSearchField"]}/> */}
 
                 <RangeFilter min={1900}
                             max={new Date().getFullYear()}
@@ -139,13 +188,15 @@ export class SearchPage extends Component<Props> {
                             id="dataCollectionYear"
                             title={counterpart.translate('filters.collectionDates.label')}
                             rangeComponent={RangeSliderInput}
-                            containerComponent={<Panel title={<Translate content='filters.collectionDates.label'/>}
-                                                        tooltip={<Tooltip id="filters-collectiondates-tooltip"
-                                                                          content={counterpart.translate("filters.collectionDates.tooltip.content")}
-                                                                          ariaLabel={counterpart.translate("filters.collectionDates.tooltip.ariaLabel")}/>}
-                                                        className="dataCollectionYear"
-                                                        collapsable={true}
-                                                        defaultCollapsed={true}/>}/>
+                            containerComponent={<Panel
+                              title={<Translate content='filters.collectionDates.label'/>}
+                              tooltip={<Tooltip id="filters-collectiondates-tooltip"
+                                                content={counterpart.translate("filters.collectionDates.tooltip.content")}
+                                                ariaLabel={counterpart.translate("filters.collectionDates.tooltip.ariaLabel")}/>}
+                              className="dataCollectionYear"
+                              collapsable={true}
+                              defaultCollapsed={true}/>
+                            }/>
 
                 <RefinementListFilter id="studyAreaCountries.searchField"
                                       title={counterpart.translate('filters.country.label')}
@@ -157,16 +208,19 @@ export class SearchPage extends Component<Props> {
                                       orderKey="_key"
                                       orderDirection="asc"
                                       operator="OR"
-                                      containerComponent={<Panel title={<Translate content='filters.country.label'/>}
-                                                                tooltip={<Tooltip id="filters-country-tooltip"
-                                                                                  content={counterpart.translate("filters.country.tooltip.content")}
-                                                                                  ariaLabel={counterpart.translate("filters.country.tooltip.ariaLabel")}/>}
-                                                                className="studyAreaCountries"
-                                                                collapsable={true}
-                                                                defaultCollapsed={true}/>}
+                                      containerComponent={<Panel
+                                        title={<Translate content='filters.country.label'/>}
+                                        tooltip={<Tooltip id="filters-country-tooltip"
+                                                          content={counterpart.translate("filters.country.tooltip.content")}
+                                                          ariaLabel={counterpart.translate("filters.country.tooltip.ariaLabel")}/>}
+                                        className="studyAreaCountries"
+                                        collapsable={true}
+                                        defaultCollapsed={true}/>
+                                      }
                                       listComponent={<MultiSelect placeholder={<Translate content='filters.country.placeholder'/>}
                                                                   ariaLabel={counterpart.translate('filters.country.label')}/>}
-                                      size={500}/>
+                                      size={500}
+                                      showMore={false}/>
 
                 <RefinementListFilter id="publisher.publisher"
                                       title={counterpart.translate('filters.publisher.label')}
@@ -178,16 +232,19 @@ export class SearchPage extends Component<Props> {
                                       orderKey="_key"
                                       orderDirection="asc"
                                       operator="OR"
-                                      containerComponent={<Panel title={<Translate content='filters.publisher.label'/>}
-                                                                tooltip={<Tooltip id="filters-publisher-tooltip"
-                                                                                  content={counterpart.translate("filters.publisher.tooltip.content")}
-                                                                                  ariaLabel={counterpart.translate("filters.publisher.tooltip.ariaLabel")}/>}
-                                                                className="publisher"
-                                                                collapsable={true}
-                                                                defaultCollapsed={true}/>}
+                                      containerComponent={<Panel
+                                        title={<Translate content='filters.publisher.label'/>}
+                                        tooltip={<Tooltip id="filters-publisher-tooltip"
+                                                          content={counterpart.translate("filters.publisher.tooltip.content")}
+                                                          ariaLabel={counterpart.translate("filters.publisher.tooltip.ariaLabel")}/>}
+                                        className="publisher"
+                                        collapsable={true}
+                                        defaultCollapsed={true}/>
+                                      }
                                       listComponent={<MultiSelect placeholder={<Translate content='filters.publisher.placeholder'/>}
                                                                   ariaLabel={counterpart.translate('filters.publisher.label')}/>}
-                                      size={500}/>
+                                      size={500}
+                                      showMore={false}/>
               </div>
             </SideBar>
             <LayoutResults className="column is-8">

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -220,7 +220,8 @@ padding: 6px 0;
 }
 
 .sk-refinement-list__view-more-action {
-  display: none;
+  font-size: 1rem;
+  color: #0D7BC6;
 }
 
 .sk-layout__body {

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -220,8 +220,7 @@ padding: 6px 0;
 }
 
 .sk-refinement-list__view-more-action {
-  font-size: 1rem;
-  color: #0D7BC6;
+  display: none;
 }
 
 .sk-layout__body {

--- a/tests/src/containers/SearchPage.tsx
+++ b/tests/src/containers/SearchPage.tsx
@@ -15,8 +15,6 @@ import _ from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { mapStateToProps, Props, SearchPage } from '../../../src/containers/SearchPage';
-import searchkit from '../../../src/utilities/searchkit';
-import { FacetAccessor } from 'searchkit';
 
 // Mock props and shallow render container for test.
 function setup(partialProps?: Partial<Props>) {
@@ -51,24 +49,6 @@ describe('SearchPage container', () => {
     });
     const searchPage = enzymeWrapper.find('SearchkitProvider');
     expect(searchPage.exists()).toBe(true);
-  });
-
-  it('should change facetsPerPage for filters if set', () => {
-    const { enzymeWrapper } = setup();
-    const instance = enzymeWrapper.instance() as SearchPage;
-    const accessors = [
-      { key: 'classifications.term', options: { facetsPerPage: 50 } },
-      { key: 'keywords.term', options: { facetsPerPage: 50 } }
-    ];
-    jest.spyOn(searchkit, 'getAccessorsByType').mockImplementation(() => accessors);
-    instance['facetsPerPage'] = {
-      'classifications.term': 10000
-    }
-    instance.componentDidMount();
-    const topicAccessor = searchkit.getAccessorsByType(FacetAccessor).find((facet: FacetAccessor) => facet.key === 'classifications.term');
-    const keywordsAccessor = searchkit.getAccessorsByType(FacetAccessor).find((facet: FacetAccessor) => facet.key === 'keywords.term');
-    expect(topicAccessor.options.facetsPerPage).toBe(10000);
-    expect(keywordsAccessor.options.facetsPerPage).toBe(50);
   });
 
   it('should apply class when mobile filters visible', () => {

--- a/tests/src/containers/SearchPage.tsx
+++ b/tests/src/containers/SearchPage.tsx
@@ -15,6 +15,8 @@ import _ from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { mapStateToProps, Props, SearchPage } from '../../../src/containers/SearchPage';
+import searchkit from '../../../src/utilities/searchkit';
+import { FacetAccessor } from 'searchkit';
 
 // Mock props and shallow render container for test.
 function setup(partialProps?: Partial<Props>) {
@@ -43,11 +45,30 @@ describe('SearchPage container', () => {
     const { enzymeWrapper } = setup();
     enzymeWrapper.setProps({
       filters: {
-        'classifications.term': ['Term']
+        'classifications.term': ['Term'],
+        'keywords_term': 'keyword'
       }
     });
     const searchPage = enzymeWrapper.find('SearchkitProvider');
     expect(searchPage.exists()).toBe(true);
+  });
+
+  it('should change facetsPerPage for filters if set', () => {
+    const { enzymeWrapper } = setup();
+    const instance = enzymeWrapper.instance() as SearchPage;
+    const accessors = [
+      { key: 'classifications.term', options: { facetsPerPage: 50 } },
+      { key: 'keywords.term', options: { facetsPerPage: 50 } }
+    ];
+    jest.spyOn(searchkit, 'getAccessorsByType').mockImplementation(() => accessors);
+    instance['facetsPerPage'] = {
+      'classifications.term': 10000
+    }
+    instance.componentDidMount();
+    const topicAccessor = searchkit.getAccessorsByType(FacetAccessor).find((facet: FacetAccessor) => facet.key === 'classifications.term');
+    const keywordsAccessor = searchkit.getAccessorsByType(FacetAccessor).find((facet: FacetAccessor) => facet.key === 'keywords.term');
+    expect(topicAccessor.options.facetsPerPage).toBe(10000);
+    expect(keywordsAccessor.options.facetsPerPage).toBe(50);
   });
 
   it('should apply class when mobile filters visible', () => {

--- a/translations/en.json
+++ b/translations/en.json
@@ -42,7 +42,7 @@
       "label": "Keywords",
       "placeholder": "Search keywords",
       "tooltip": {
-        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords.",
+        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords. Searchable list contains %(size)s most common keywords.",
         "ariaLabel": "Tooltip button for Keywords filter"
       }
     },

--- a/translations/en.json
+++ b/translations/en.json
@@ -25,11 +25,16 @@
     "resetSearch": "Reset Search"
   },
   "filters": {
+    "view": {
+      "more": "Add %(facetsPerPage)s more %(name)s to searchable %(name)s list",
+      "less": "Keep only %(defaultSize)s most common %(name)s in searchable %(name)s list",
+      "all": "Add all %(name)s to searchable %(name)s list"
+    },
     "topic": {
       "label": "Topic",
       "placeholder": "Search topics",
       "tooltip": {
-        "content": "<a href=\"https://vocabularies.cessda.eu/vocabulary/TopicClassification?lang=en\">CESSDA Topic Classification</a> serves to identify the general topics, subjects or themes of a study. Note: Some studies use other topic classifications and are not included in the filter.",
+        "content": "Topic terms serve to identify the general topics, subjects or themes of a study. Many but not all metadata providers use <a href=\"https://vocabularies.cessda.eu/vocabulary/TopicClassification?lang=en\">CESSDA Topic Classification</a> for their topic terms.",
         "ariaLabel": "Tooltip button for Topic filter"
       }
     },
@@ -37,7 +42,7 @@
       "label": "Keywords",
       "placeholder": "Search keywords",
       "tooltip": {
-        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords. Search term can be truncated by using the asterisk (*) after the search term, e.g. discrim*.",
+        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords.",
         "ariaLabel": "Tooltip button for Keywords filter"
       }
     },

--- a/translations/en.json
+++ b/translations/en.json
@@ -42,7 +42,7 @@
       "label": "Keywords",
       "placeholder": "Search keywords",
       "tooltip": {
-        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords. Searchable list contains %(size)s most common keywords.",
+        "content": "Keywords which describe the content of the data. Many but not all metadata providers use <a href=\"https://elsst.cessda.eu/\">ELSST Thesaurus</a> for their keywords. Searchable list contains a maximum of %(size)s most common keywords.",
         "ariaLabel": "Tooltip button for Keywords filter"
       }
     },


### PR DESCRIPTION
Mostly happy with how keywords filter works here but still not sure about the way I used searchkit's RefinementListFilter's showMore with increased facetsPerPage to make it possible to easily search from all keywords. Having all keywords listed and searchable makes the dropdown slightly slow to open on my PC/browser/dev server at least but I still think it's good to have that option. It would also look better with the texts being "Search from all keywords" and "Search from 2000 most common keywords" but it's more ambiguous (could think it needs to be pressed to initiate the search).

Might still be better to just decide on a number of keywords to show/search from and disable showMore for keywords also. It would still work when clicking a keyword in Detail view even if the keyword is normally too uncommon to show up in dropdown.

Also changed Topic filter tooltip text and fixed a key in Similars to be in right spot and to use id instead of index.

In any case, both Topic and Keywords filter would benefit from having a normalized field being used for the list but that would mean changes to the index:
Adding a normalizer in index settings in analysis:
```json
  "settings": {
    "..."
    "analysis": {
      "analyzer": {
        "..."
      },
      "normalizer": {
        "lowercase_asciifolding": {
          "type": "custom",
          "char_filter": [],
          "filter": [
            "lowercase",
            "asciifolding"
          ]
        }
      }
    }
  },
```
Using it for classifications and keywords:
```json
      "classifications": {
        "type": "nested",
        "properties": {
          "...",
          "term": {
            "type": "keyword",
            "ignore_above": 256,
            "copy_to": "classificationsSearchField",
            "fields": {
              "normalized": {
                "type": "keyword",
                "normalizer": "lowercase_asciifolding"
              }
            }
          },
          "..."
        }
      },
      "keywords": {
        "type": "nested",
        "properties": {
          "...",
          "term": {
            "type": "text",
            "analyzer": "pasc_index_autocomplete_analyzer",
            "search_analyzer": "pasc_standard_analyzer",
            "term_vector": "with_positions_offsets",
            "copy_to": [ "keywordsSearchField", "keywordsKeywordField" ],
            "fields": {
              "normalized": {
                "type": "keyword",
                "normalizer": "lowercase_asciifolding"
              }
            }
          },
          "..."
        }
      },
```
And then using the normalized fields in RefinementListFilter:
```js
<RefinementListFilter id="classifications.term"
                       ...
                      field={'classifications.term.normalized'}
                      fieldOptions={{
                      type: 'nested',
                        options: {path: 'classifications', min_doc_count: 1}
                      }}
                      ...
>
<RefinementListFilter id="keywords.term"
                      ...
                      field={'keywords.term.normalized'}
                      fieldOptions={{
                      type: 'nested',
                        options: {path: 'keywords', min_doc_count: 1}
                      }}
                      ...
>

```