### PR TITLE
#563: Add main landmark regions, add link to front page on main nav…

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -111,7 +111,7 @@ export class Header extends Component<Props> {
               </div>
             </div>
             <div className="column">
-              <div className="search-wrapper">
+              <div className="search-wrapper" role="search">
                 <SearchBox
                   autofocus={true}
                   searchOnChange={true}
@@ -157,11 +157,12 @@ export class Header extends Component<Props> {
               <div className="column is-centered is-hidden-touch">
                 {pathname === "/" && <HitsStats className="hits-count" />}
               </div>
-              <div className="column has-text-right-tablet has-text-left-mobile is-narrow-touch">
+              <nav className="column has-text-right-tablet has-text-left-mobile is-narrow-touch" aria-label="Main">
+                <Translate component={Link} to="/" className="is-sr-only is-hidden-mobile" content="header.frontPage"/>
                 <Translate component={Link} to="/about" className="sk-reset-filters link is-hidden-mobile" content="about.label"/>
                 <Translate component="a" href="/documentation" className="sk-reset-filters link is-hidden-mobile" content="documentation.label"/>
                 <Translate component="a" href="https://api.tech.cessda.eu/" className="sk-reset-filters link is-hidden-mobile" content="api.label"/>
-              </div>
+              </nav>
             </div>
           </div>
         </div>

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -114,65 +114,59 @@ export class Result extends Component<Props, ComponentState> {
             <span dangerouslySetInnerHTML={{__html: item.abstractHighlightShort || item.abstractShort}}/>
           }
         </div>
-        <span className="level mt-10 result-actions">
-          <span className="level-left is-hidden-touch">
-            <div className="field is-grouped">
-              <div className="control">
-                {item.abstract.length > 500 &&
-                 <a className={bemBlocks.item().mix('button is-small is-white')} onClick={() => {
-                  // Notify Matomo Analytics of toggling "Read more" for a study.
-                  const _paq = getPaq();
-                  _paq.push(['trackEvent', 'Search', 'Read more', item.titleStudy]);
+        <div className="result-actions mt-10">
+          <div className="is-flex is-hidden-touch">
+            {item.abstract.length > 500 &&
+              <a className={bemBlocks.item().mix('button is-small is-white')} onClick={() => {
+              // Notify Matomo Analytics of toggling "Read more" for a study.
+              const _paq = getPaq();
+              _paq.push(['trackEvent', 'Search', 'Read more', item.titleStudy]);
 
-                  this.setState(state => ({
-                    abstractExpanded: !state.abstractExpanded
-                  }));
-                 }}>
-                   {this.state.abstractExpanded ?
-                    <>
-                      <span className="icon is-small"><FaAngleUp/></span>
-                      <Translate component="span" content="readLess"/>
-                    </>
-                   :
-                    <>
-                      <span className="icon is-small"><FaAngleDown/></span>
-                      <Translate component="span" content="readMore"/>
-                    </>
-                   }
-                 </a>
+              this.setState(state => ({
+                abstractExpanded: !state.abstractExpanded
+              }));
+              }}>
+                {this.state.abstractExpanded ?
+                <>
+                  <span className="icon is-small"><FaAngleUp/></span>
+                  <Translate component="span" content="readLess"/>
+                </>
+                :
+                <>
+                  <span className="icon is-small"><FaAngleDown/></span>
+                  <Translate component="span" content="readMore"/>
+                </>
                 }
-              </div>
-            </div>
-          </span>
-          <span className="level-right">
-            <div className="field is-grouped is-grouped-multiline">
-              {languages.length > 0 &&
-               <div className="control">
-                 <div className="buttons has-addons">
-                  <span className="button is-small is-white bg-w pe-none">
-                    <span className="icon is-small">
-                      <FaLanguage/>
-                    </span>
-                    <span><Translate content="language.label"/>:</span>
+              </a>
+            }
+          </div>
+          <div className="is-flex">
+            {languages.length > 0 &&
+              <div className="buttons has-addons">
+                <span className="button is-small is-white bg-w pe-none">
+                  <span className="icon is-small">
+                    <FaLanguage/>
                   </span>
-                   {languages}
-                 </div>
-               </div>
-              }
-              <div className="control">
-                {item.studyUrl &&
-                 <a className="button is-small is-white"
-                    href={item.studyUrl}
-                    rel="noreferrer"
-                    target="_blank">
-                   <span className="icon is-small"><FaExternalLinkAlt/></span>
-                   <Translate component="span" content="goToStudy"/>
-                 </a>
-                }
+                  <span><Translate content="language.label"/>:</span>
+                </span>
+                <span>
+                  {languages}
+                </span>
               </div>
-            </div>
-          </span>
-        </span>
+            }
+            <span>
+              {item.studyUrl &&
+                <a className="button is-small is-white"
+                  href={item.studyUrl}
+                  rel="noreferrer"
+                  target="_blank">
+                  <span className="icon is-small"><FaExternalLinkAlt/></span>
+                  <Translate component="span" content="goToStudy"/>
+                </a>
+              }
+            </span>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/containers/AboutPage.tsx
+++ b/src/containers/AboutPage.tsx
@@ -37,7 +37,7 @@ export class AboutPage extends Component {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <div className="container">
+          <main className="container">
           <LayoutBody className="columns">
             <LayoutResults>
               <article className="about-container">
@@ -46,7 +46,7 @@ export class AboutPage extends Component {
               </article>
             </LayoutResults>
           </LayoutBody>
-          </div>
+          </main>
           <Footer/>
         </Layout>
       </SearchkitProvider>

--- a/src/containers/DetailPage.tsx
+++ b/src/containers/DetailPage.tsx
@@ -116,7 +116,7 @@ export class DetailPage extends Component<Props> {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <div className="container mb-3">
+          <main className="container mb-3">
           <LayoutBody className="columns">
             <SideBar className="is-hidden-mobile column is-4">
               <Panel title={<Translate content='similarResults.heading'/>}
@@ -168,7 +168,7 @@ export class DetailPage extends Component<Props> {
             }
             </LayoutResults>
           </LayoutBody>
-          </div>
+          </main>
           <Footer/>
         </Layout>
       </SearchkitProvider>

--- a/src/containers/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage.tsx
@@ -38,7 +38,7 @@ export class AboutPage extends Component {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <div className="container">
+          <main className="container">
             <LayoutBody className="columns">
               <LayoutResults className="not-found-layout">
                 <article className="not-found-container">
@@ -52,7 +52,7 @@ export class AboutPage extends Component {
                 <Link to="/">Return to the home page</Link> | <a href="https://www.cessda.eu">CESSDA main website</a>
               </div>
             </div>
-          </div>
+          </main>
           <Footer/>
         </Layout>
       </SearchkitProvider>

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -88,7 +88,7 @@ export class SearchPage extends Component<Props> {
       <SearchkitProvider searchkit={searchkit}>
         <Layout className={showMobileFilters ? 'show-mobile-filters' : ''}>
           <Header/>
-          <div className="container">
+          <main className="container">
           <LayoutBody className="columns">
             <SideBar className="column is-4">
               <div className="float">
@@ -229,7 +229,7 @@ export class SearchPage extends Component<Props> {
                                    listComponent={<Pagination ariaLabel={counterpart.translate('pagination.navBottom')}/>}/>
             </LayoutResults>
           </LayoutBody>
-          </div>
+          </main>
           <Footer/>
         </Layout>
       </SearchkitProvider>

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -148,7 +148,15 @@ body {
   .button-wrapper {
     .dropdown {
       margin-top: 30px;
+
+      @include mobile {
+        position: absolute;
+        right: 0;
+        z-index: 3;
+        margin-top: -63px;
+      }
     }
+
     button {
       height: 45px;
     }
@@ -274,8 +282,17 @@ padding: 6px 0;
   }
 }
 
-.result-actions .button {
-  font-size: 13px;
+.result-actions {
+  display: flex;
+  justify-content: space-between;
+
+  .is-flex .buttons {
+    margin-bottom: -0.5rem !important;
+  }
+
+  @include touch {
+    justify-content: flex-end;
+  }
 }
 
 .list_hit {


### PR DESCRIPTION
… for screen readers, move search tooltip button on mobile, fix buttons in results overflowing with multiple languages or low resolution

Search tooltip button in header now goes partly on top of language select with low resolution but I thought it's actually good that way since it still looks good (never goes on top of the text) and also saves space when it's needed so didn't try to change it further. 