### PR TITLE
Only add a keywords query if keywords are being sent to the API

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -341,11 +341,14 @@ function externalApiV2() {
       });
     }
 
-    //Create json body for ElasticSearchClient - nested post-filters
+    // Create json body for ElasticSearchClient - nested post-filters
     buildNestedFilters(bodyQuery, req.query.classifications, 'classifications', 'classifications.term');
     buildNestedFilters(bodyQuery, req.query.studyAreaCountries, 'studyAreaCountries', 'studyAreaCountries.searchField');
     buildNestedFilters(bodyQuery, req.query.publishers, 'publisherFilter', 'publisherFilter.publisher');
-    bodyQuery.query('simple_query_string', { query: req.query.keywords, fields: ["keywordsSearchField"] });
+
+    if (req.query.keywords) {
+      bodyQuery.query('simple_query_string', { query: req.query.keywords, fields: ["keywordsSearchField"] });
+    }
 
     //Create json body for ElasticSearchClient - date-filters
     let dataCollectionYearMin = req.query.dataCollectionYearMin ? Number(req.query.dataCollectionYearMin) : undefined;
@@ -360,20 +363,7 @@ function externalApiV2() {
       bodyQuery.filter('range', 'dataCollectionYear', { gte: dataCollectionYearMin, lte: dataCollectionYearMax });
     }
 
-    //Meta-Info to send with response
-    const searchTerms = {
-      metadataLanguage: metadataLanguage,
-      queryTerm: q,
-      limit: req.query.limit,
-      offset: req.query.offset,
-      classifications: req.query.classifications,
-      studyAreaCountries: req.query.studyAreaCountries,
-      publishers: req.query.publishers,
-      dataCollectionYearMin: req.query.dataCollectionYearMin,
-      dataCollectionYearMax: req.query.dataCollectionYearMax,
-      keywords: req.query.keywords,
-      sortBy: req.query.sortBy
-   }
+    
 
     //Prepare the Client
     try {
@@ -401,6 +391,21 @@ function externalApiV2() {
       }
 
       const resultsCount = apiResultsCount(offset, limit, response.hits.hits.length, totalHits);
+
+      //Meta-Info to send with response
+      const searchTerms = {
+        metadataLanguage: metadataLanguage,
+        queryTerm: q,
+        limit: req.query.limit,
+        offset: req.query.offset,
+        classifications: req.query.classifications,
+        studyAreaCountries: req.query.studyAreaCountries,
+        publishers: req.query.publishers,
+        dataCollectionYearMin: req.query.dataCollectionYearMin,
+        dataCollectionYearMax: req.query.dataCollectionYearMax,
+        keywords: req.query.keywords,
+        sortBy: req.query.sortBy
+      }
 
       /* 
        * Send the Response.

--- a/server/metrics.ts
+++ b/server/metrics.ts
@@ -136,13 +136,13 @@ export const languageGauge = new client.Gauge({
   labelNames: ['language'],
 });
 //Function to get Studies Languages Metrics
-const languageGauges = async () => {
+async function languageGauges() {
   const results = await getESindexLanguages();
   for (const result of results) {
     const currentValue = await getESrecordsByLanguages(result);
     languageGauge.set({ language: result }, currentValue);
   }
-};
+}
 //Metrics for ES - Studies Endpoints
 export const endpointGauge = new client.Gauge({
   name: 'studies_endpoints',
@@ -150,12 +150,10 @@ export const endpointGauge = new client.Gauge({
   labelNames: ['endpoint'],
 });
 //Function to get Studies Endpoints Metrics
-const endpointGauges = async () => {
+async function endpointGauges() {
   const results = await getESrecordsByEndpoint();
-  results.forEach(( result: { key: string, doc_count: number } ) => {
-    endpointGauge.set({ endpoint: result.key }, result.doc_count);
-  });
-};
+  results.forEach(result => endpointGauge.set({ endpoint: result.key }, result.doc_count));
+}
 //Metrics for SearchAPI - Track Visitors IP's
 export const searchAPIClientIPGauge = new client.Gauge({
   name: 'searchAPI_client_ip',
@@ -179,9 +177,10 @@ export function startMetricsListening() {
 
     client.collectDefaultMetrics(); //general cpu, mem, etc information
 
-    router.get('/', async (_req, res) => 
-      res.type(client.register.contentType).send(await client.register.metrics())
-    );
+    router.get('/', async (_req, res) => {
+      const metrics = await client.register.metrics();
+      res.type(client.register.contentType).send(metrics);
+    });
 
     return router;
 }
@@ -212,7 +211,7 @@ export function uiResponseTimeHandler(req: Request, res: Response, time: number)
       }, time);
 
       //PUBLISHER
-      const urlUI = new URL(String(req.headers.referer));
+      const urlUI = new URL(req.headers.referer);
       const paramsUI = new URLSearchParams(urlUI.search);
       if (paramsUI.has('publisher.publisher[0]')) { //searching for at least 1 publisher
         paramsUI.forEach(function (value, key) {


### PR DESCRIPTION
This fixes an invalid simple_query_string query being sent to Elasticsearch, fixing broken Postman tests.