### PR TITLE
Add styles for feedback button and form, remove placeholder texts from feedback form

### DIFF
--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -93,7 +93,7 @@
   <% } %>  
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
  
-  <button id="zammad-feedback-form" style="position: fixed; right: 0; bottom: 0;" >Send feedback</button>
+  <button id="zammad-feedback-form" class="button is-info">Send feedback</button>
   <script id="zammad_form_script" src="https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js"></script>
   <script>
     $(function() {
@@ -112,7 +112,7 @@
            type: 'text',
            id: 'zammad-form-name',
            required: true,
-           placeholder: 'Your Name',
+           placeholder: '',
            defaultValue: '',
          },
          {
@@ -122,7 +122,7 @@
            type: 'email',
            id: 'zammad-form-email',
            required: true,
-           placeholder: 'Your Email',
+           placeholder: '',
            defaultValue: '',
          },
          {
@@ -131,7 +131,7 @@
            tag: 'input',
            id: 'zammad-form-subject',
            required: false,
-           placeholder: 'My subject',
+           placeholder: '',
            defaultValue: '',
          },
          {
@@ -140,7 +140,7 @@
            tag: 'textarea',
            id: 'zammad-form-body',
            required: true,
-           placeholder: 'Your Message...',
+           placeholder: '',
            defaultValue: '',
            rows: 7,
          }

--- a/src/styles/design.scss
+++ b/src/styles/design.scss
@@ -17,6 +17,7 @@
 @import 'modules/_branding.scss';
 @import 'modules/_warnings.scss';
 @import 'modules/_utility.scss';
+@import 'modules/_feedback.scss';
 
 /* Import font faces */
 @import url('https://fonts.googleapis.com/css?family=Kanit');

--- a/src/styles/modules/_feedback.scss
+++ b/src/styles/modules/_feedback.scss
@@ -1,0 +1,25 @@
+#zammad-feedback-form {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+}
+
+.zammad-form {
+  display: flex;
+  flex-direction: column;
+
+  .zammad-form-group {
+    color: #333;
+
+    .zammad-form-control {
+      font-size: 1rem;
+      padding: 2px;
+    }
+  }
+
+  .btn {
+    @extend .button;
+    @extend .is-info;
+    margin: auto;
+  }
+}


### PR DESCRIPTION
Form styles rely on class names used in https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js but I'd assume it's safe to do so and they won't suddenly be changed/removed without warning (some deprecation warnings are in the script but not for these).

Leaving out autocomplete attributes from this ([WCAG 2.1 SC 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)), e.g. autocomplete="name". This is something that would generally require changes to the previously mentioned script (either directly add attributes there or add support for custom attributes).