### PR TITLE
#562: Improve keyboard navigation, focus order and visible focus, add skip to main

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -47,7 +47,7 @@ export default class Pagination extends AbstractItemList {
         const current = items[i].page === selectedItems[0] ? ' is-current' : '';
         links.push(
           <li key={items[i].key}>
-            <a className={'pagination-link' + current}
+            <a className={'pagination-link focus-visible' + current}
                href={'/?p=' + items[i].page}
                aria-label={counterpart.translate('pagination.page') + items[i].page}
                onClick={(e) => {
@@ -64,7 +64,7 @@ export default class Pagination extends AbstractItemList {
     return (
       <nav className="pagination is-centered is-small" role="navigation"
            aria-label={ariaLabel + selectedItems[0]}>
-        <a className="pagination-previous"
+        <a className="pagination-previous focus-visible"
            href={'/?p=' + items[0].page}
            aria-label={counterpart.translate('pagination.previous') + items[0].page}
            onClick={(e) => {
@@ -73,7 +73,10 @@ export default class Pagination extends AbstractItemList {
             }}>
           <FaChevronLeft/>
         </a>
-        <a className="pagination-next"
+        <ul className="pagination-list">
+          {links}
+        </ul>
+        <a className="pagination-next focus-visible"
            href={'/?p=' + items[items.length - 1].page}
            aria-label={counterpart.translate('pagination.next') + items[items.length - 1].page}
            onClick={(e) => {
@@ -82,9 +85,6 @@ export default class Pagination extends AbstractItemList {
             }}>
           <FaChevronRight/>
         </a>
-        <ul className="pagination-list">
-          {links}
-        </ul>
       </nav>
     );
   }

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -62,13 +62,24 @@ export class Panel extends SearchkitPanel {
     }
   }
 
+  handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    // If panels contain elements that shouldn't toggle collapse for the container, they need to be excluded here (like 'a' and 'button')
+    if ((event.key === 'Enter' || event.key === ' ') && !['a', 'button'].includes((event.target as HTMLElement).tagName.toLowerCase())) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.toggleCollapsed();
+    }
+  };
+
   render() {
     const {
       tooltip
     } = this.props;
 
     return (
-      <section className={'sk-panel__container' + (this.state.collapsed ? ' sk-panel__collapsed' : '')}>
+      <section className={'sk-panel__container' + (this.state.collapsed ? ' sk-panel__collapsed' : '')}
+               tabIndex={this.props.collapsable ? 0 : -1}
+               onKeyDown={this.props.collapsable ? (e) => this.handleKeyDown(e) : undefined }>
         {tooltip}
         {super.render()}
       </section>

--- a/src/components/Reset.tsx
+++ b/src/components/Reset.tsx
@@ -37,7 +37,8 @@ export function Reset(props: Props) {
           if (pathname === '/' && hasFilters) {
             resetFilters();
           }
-        }}>
+        }}
+        tabIndex={0}>
       {translate('reset.clear_all')}
     </a>
   );

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -55,6 +55,24 @@ function generateCreatorElements(item: CMMStudy) {
 
 export class Result extends Component<Props, ComponentState> {
 
+  handleKeyDown(event: React.KeyboardEvent, titleStudy: string) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.handleAbstractExpansion(titleStudy);
+    }
+  };
+
+  handleAbstractExpansion(titleStudy: string) {
+    // Notify Matomo Analytics of toggling "Read more" for a study.
+    const _paq = getPaq();
+    _paq.push(['trackEvent', 'Search', 'Read more', titleStudy]);
+
+    this.setState(state => ({
+      abstractExpanded: !state.abstractExpanded
+    }));
+  }
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -77,7 +95,7 @@ export class Result extends Component<Props, ComponentState> {
     for (let i = 0; i < item.langAvailableIn.length; i++) {
       languages.push(
         <Link key={i}
-              className="button is-small is-white" 
+              className="button is-small is-white focus-visible"
               to={{
                 pathname: '/detail',
                 query: {
@@ -117,15 +135,9 @@ export class Result extends Component<Props, ComponentState> {
         <div className="result-actions mt-10">
           <div className="is-flex is-hidden-touch">
             {item.abstract.length > 500 &&
-              <a className={bemBlocks.item().mix('button is-small is-white')} onClick={() => {
-              // Notify Matomo Analytics of toggling "Read more" for a study.
-              const _paq = getPaq();
-              _paq.push(['trackEvent', 'Search', 'Read more', item.titleStudy]);
-
-              this.setState(state => ({
-                abstractExpanded: !state.abstractExpanded
-              }));
-              }}>
+              <a className={bemBlocks.item().mix('button is-small is-white focus-visible')} tabIndex={0}
+                onClick={() => this.handleAbstractExpansion(item.titleStudy)}
+                onKeyDown={(e) => this.handleKeyDown(e, item.titleStudy)}>
                 {this.state.abstractExpanded ?
                 <>
                   <span className="icon is-small"><FaAngleUp/></span>
@@ -156,7 +168,7 @@ export class Result extends Component<Props, ComponentState> {
             }
             <span>
               {item.studyUrl &&
-                <a className="button is-small is-white"
+                <a className="button is-small is-white focus-visible"
                   href={item.studyUrl}
                   rel="noreferrer"
                   target="_blank">

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -53,7 +53,7 @@ export default ({ content, id, ariaLabel }: TooltipProps) => {
          onMouseEnter={() => setIsActive(true)}
          onMouseLeave={() => setIsActive(false)}>
       <div className="dropdown-trigger">
-        <button ref={tooltipButtonRef} className="button" aria-haspopup="true"
+        <button ref={tooltipButtonRef} className="button focus-visible" aria-haspopup="true"
                 {...(isActive ? {'aria-describedby': id} : {'aria-label': ariaLabel})}
                 onClick={(e) => handleClick(e)}
                 onKeyDown={(e) => handleKeyDown(e)}>

--- a/src/containers/AboutPage.tsx
+++ b/src/containers/AboutPage.tsx
@@ -37,7 +37,7 @@ export class AboutPage extends Component {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <main className="container">
+          <main id="main" className="container">
           <LayoutBody className="columns">
             <LayoutResults>
               <article className="about-container">

--- a/src/containers/DetailPage.tsx
+++ b/src/containers/DetailPage.tsx
@@ -116,7 +116,7 @@ export class DetailPage extends Component<Props> {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <main className="container mb-3">
+          <main id="main" className="container mb-3">
           <LayoutBody className="columns">
             <SideBar className="is-hidden-mobile column is-4">
               <Panel title={<Translate content='similarResults.heading'/>}
@@ -129,12 +129,8 @@ export class DetailPage extends Component<Props> {
             {item ? 
               <>
                 <div className="panel">
-                  <a className="button is-small is-white is-pulled-right" onClick={goBack}>
-                    <FaAngleLeft/><Translate className="ml-5" content="back"/>
-                  </a>
-        
                   {item.studyUrl &&
-                  <a className="button is-small is-white is-pulled-left"
+                  <a className="button is-small is-white is-pulled-left mr-3 focus-visible"
                       href={item.studyUrl}
                       rel="noreferrer"
                       target="_blank">
@@ -143,12 +139,16 @@ export class DetailPage extends Component<Props> {
                   </a>
                   } 
         
-                  <a className="button is-small is-white is-pulled-left"
+                  <a className="button is-small is-white is-pulled-left focus-visible"
                     href={`/api/json/${index}/${encodeURIComponent(item.id)}`}
                     rel="noreferrer"
                     target="_blank">
                   <span className="icon is-small"><FaCode/></span>
                   <Translate content="viewJson"/>
+                  </a>
+
+                  <a className="button is-small is-white is-pulled-right focus-visible" onClick={goBack} tabIndex={0}>
+                    <FaAngleLeft/><Translate className="ml-5" content="back"/>
                   </a>
         
                   <div className="is-clearfix"/>

--- a/src/containers/NotFoundPage.tsx
+++ b/src/containers/NotFoundPage.tsx
@@ -38,7 +38,7 @@ export class AboutPage extends Component {
       <SearchkitProvider searchkit={searchkit}>
         <Layout>
           <Header/>
-          <main className="container">
+          <main id="main" className="container">
             <LayoutBody className="columns">
               <LayoutResults className="not-found-layout">
                 <article className="not-found-container">

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -88,7 +88,7 @@ export class SearchPage extends Component<Props> {
       <SearchkitProvider searchkit={searchkit}>
         <Layout className={showMobileFilters ? 'show-mobile-filters' : ''}>
           <Header/>
-          <main className="container">
+          <main id="main" className="container">
           <LayoutBody className="columns">
             <SideBar className="column is-4">
               <div className="float">

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -85,7 +85,7 @@ body {
   .language-picker {
     height: 42px;
     padding-top: 0;
-    padding-right: 15px;
+    margin-right: 15px;
     font-size: 14px;
     font-weight: 500;
     z-index: 2;
@@ -95,7 +95,7 @@ body {
       top: 1px;
       right: 1px;
       background:#fff;
-      padding-left: 15px;
+      margin-left: 15px;
       color: #555;
       
      
@@ -160,6 +160,16 @@ body {
     button {
       height: 45px;
     }
+  }
+
+  .skip-link-wrapper:before {
+    content: "";
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+  }
+  .skip-link-wrapper {
+    position: relative;
   }
 
   .search-wrapper {
@@ -428,4 +438,17 @@ padding: 6px 0;
 
 select::-ms-expand {
   display: none;
+}
+
+:focus-visible,
+.focus-visible:focus-visible,
+.is-focused:focus-visible,
+.sk-select select:focus-visible,
+.language-picker:focus-within .Select-control {
+  outline: #fdc29b solid 2px;
+}
+
+.sk-panel__container,
+.button-wrapper .dropdown .dropdown-trigger button {
+  outline-offset: 1px;
 }

--- a/src/styles/modules/_header.scss
+++ b/src/styles/modules/_header.scss
@@ -83,7 +83,7 @@ header {
     color: $light_grey;
     height: 45px;
     max-width: 600px;
-    margin: 0 auto;
+    margin: 0 15px 0 0;
     z-index: 1;
 
     &.is-focused {

--- a/src/styles/modules/_tooltip.scss
+++ b/src/styles/modules/_tooltip.scss
@@ -14,6 +14,9 @@
         background: none;
         border: none;
       }
+      button:focus-visible {
+        box-shadow: none;
+      }
     }
 
     .dropdown-menu {

--- a/tests/src/components/Header.tsx
+++ b/tests/src/components/Header.tsx
@@ -83,6 +83,59 @@ describe('Header component', () => {
     expect(enzymeWrapper.find('.modal.is-active').exists()).toBe(true);
   });
 
+  it('should click target element after pressing enter or space on any filter related button', () => {
+    const linkButtonMockFunction = jest.fn();
+    const { enzymeWrapper } = setup({
+      filters: {
+        'classifications.term': ['Term'],
+        'keywords_term': 'keyword'
+      }
+    });
+    const linkButtonMock = document.createElement('a');
+    linkButtonMock.addEventListener( 'click', () => linkButtonMockFunction());
+    enzymeWrapper.find('#toggle-mobile-filters').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                      target: linkButtonMock,
+                                                                      key: 'Enter', keyCode: 13, which: 13 })
+    enzymeWrapper.find('#toggle-summary').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                target: linkButtonMock,
+                                                                key: ' ', keyCode: 32, which: 32 })
+    enzymeWrapper.find('#reset-filters').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                              target: linkButtonMock,
+                                                              key: 'Enter', keyCode: 13, which: 13 })
+    enzymeWrapper.find('#clear-search').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                              target: linkButtonMock,
+                                                              key: ' ', keyCode: 32, which: 32 })
+    expect(linkButtonMockFunction).toBeCalledTimes(4);
+  });
+
+  it('should toggle is-sr-only class for screen reader only elements on focus and blur', () => {
+    const { enzymeWrapper } = setup();
+    const linkMock = document.createElement('a');
+    linkMock.classList.add('is-sr-only');
+    const srOnlyElements = enzymeWrapper.find('.is-sr-only');
+    srOnlyElements.forEach(element => {
+      element.simulate('focus', { target: linkMock });
+      expect(linkMock.classList).not.toContain('is-sr-only');
+      element.simulate('blur', { target: linkMock });
+      expect(linkMock.classList).toContain('is-sr-only');
+    });
+  });
+
+  it('should focus toggle summary element after closing filter summary window', () => {
+    jest.spyOn(React, 'createRef').mockReturnValueOnce({ current: document.createElement('a') });
+    const { enzymeWrapper } = setup({
+      filters: {
+        'classifications.term': ['Term'],
+        'keywords_term': 'keyword'
+      },
+      showFilterSummary: true
+    });
+    const focusToggleSummarySpy = jest.spyOn((enzymeWrapper.instance() as Header), 'focusToggleSummary')
+    enzymeWrapper.find('#close-filter-summary-top').simulate('click', { preventDefault(){}, stopPropagation(){}});
+    enzymeWrapper.find('#close-filter-summary-bottom').simulate('click', { preventDefault(){}, stopPropagation(){}});
+    expect(focusToggleSummarySpy).toBeCalledTimes(2);
+  });
+
   it('should map state to props', () => {
     const { props } = setup();
     expect(

--- a/tests/src/components/Panel.tsx
+++ b/tests/src/components/Panel.tsx
@@ -93,6 +93,26 @@ describe('Panel component', () => {
     expect(props.expandMetadataPanels).toBe(false);
   });
 
+  it('should toggle collapsed when pressing enter or space except for exclusions', () => {
+    const { enzymeWrapper } = setup({
+      collapsable: true
+    });
+    const toggleCollapsedSpy = jest.spyOn((enzymeWrapper.instance() as Panel), 'toggleCollapsed')
+    const panelMock = document.createElement('section');
+    enzymeWrapper.find('.sk-panel__container').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                    target: panelMock,
+                                                                    key: 'Enter', keyCode: 13, which: 13 })
+    enzymeWrapper.find('.sk-panel__container').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                    target: panelMock,
+                                                                    key: ' ', keyCode: 32, which: 32 })
+    // Pressing enter on a link inside panel shouldn't toggle collapse
+    const linkInsidePanelMock = document.createElement('a');
+    enzymeWrapper.find('.sk-panel__container').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                    target: linkInsidePanelMock,
+                                                                    key: 'Enter', keyCode: 13, which: 13 })
+    expect(toggleCollapsedSpy).toBeCalledTimes(2);
+  });
+
   it('should map state to props', () => {
     const { props } = setup();
     expect(

--- a/tests/src/components/Result.tsx
+++ b/tests/src/components/Result.tsx
@@ -128,6 +128,18 @@ describe('Result component', () => {
     ).toBeGreaterThan(0);
   });
 
+  it('should toggle abstract when pressing enter or space', () => {
+    const { enzymeWrapper } = setup();
+    const handleAbstractExpansionSpy = jest.spyOn((enzymeWrapper.instance() as Result), 'handleAbstractExpansion')
+    enzymeWrapper.find('.button').first().simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                key: 'Enter', keyCode: 13, which: 13 },
+                                                              'Study title')
+    enzymeWrapper.find('.button').first().simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                key: ' ', keyCode: 32, which: 32 },
+                                                              'Study title')
+    expect(handleAbstractExpansionSpy).toBeCalledTimes(2);
+  });
+
   it('should change language', () => {
     const { props, enzymeWrapper } = setup();
     expect(props.changeLanguage).not.toHaveBeenCalled();

--- a/translations/en.json
+++ b/translations/en.json
@@ -201,7 +201,8 @@
     "relatedPublications": "Related publications"
   },
   "header": {
-    "frontPage": "Front/search page"
+    "frontPage": "Front/search page",
+    "skipToMain": "Skip to main content"
   },
   "footer": {
     "mainWebsite": "Main website of CESSDA",


### PR DESCRIPTION
Fixes almost all issues with keyboard navigation. Still can't tab to selected filter values in side panel or filter summary window but everything is still technically usable with just keyboard because all the filters can easily be cleared with "Reset filters".

Outline color for visible focus is the same light orange that is used in some places on main CESSDA website since it looked better than just black outline.

"Skip to main content" link is vertically centered with quite oldschool CSS trick but using Bulma's is-vcentered on the parent with columns class would require changing CSS for all the elements in header (above bluestripe).