### PR TITLE
#609: Use normalized field for Topic and Keywords filters

### DIFF
--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -94,7 +94,7 @@ export class SearchPage extends Component<Props> {
               <div className="float">
                 <RefinementListFilter id="classifications.term"
                                       title={counterpart.translate('filters.topic.label')}
-                                      field={'classifications.term'}
+                                      field={'classifications.term.raw'}
                                       fieldOptions={{
                                         type: 'nested',
                                         options: {path: 'classifications', min_doc_count: 1}
@@ -118,7 +118,11 @@ export class SearchPage extends Component<Props> {
 
                 <RefinementListFilter id="keywords.term"
                                       title={counterpart.translate('filters.keywords.label')}
-                                      field={'keywordsKeywordField'}
+                                      field={'keywords.term.raw'}
+                                      fieldOptions={{
+                                        type: 'nested',
+                                        options: {path: 'keywords', min_doc_count: 1}
+                                      }}
                                       orderKey="_count"
                                       orderDirection="desc"
                                       operator="OR"


### PR DESCRIPTION
Requires the index changes from https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/41 to work.