### PR TITLE
#610: Fix Panel to not toggle collapsed when target of keyboard event is in content

### DIFF
--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -63,8 +63,15 @@ export class Panel extends SearchkitPanel {
   }
 
   handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    const contentElements = document.querySelectorAll('.sk-panel__content')
+    const isTargetInContent = Array.from(contentElements).some((contentElement) =>
+      contentElement.contains(event.target as HTMLElement)
+    );
+
     // If panels contain elements that shouldn't toggle collapse for the container, they need to be excluded here (like 'a' and 'button')
-    if ((event.key === 'Enter' || event.key === ' ') && !['a', 'button'].includes((event.target as HTMLElement).tagName.toLowerCase())) {
+    // Not needed for elements in content part since they are excluded anyway
+    if ((event.key === 'Enter' || event.key === ' ') && !isTargetInContent &&
+        !['a', 'button'].includes((event.target as HTMLElement).tagName.toLowerCase())) {
       event.preventDefault();
       event.stopPropagation();
       this.toggleCollapsed();

--- a/tests/src/components/Header.tsx
+++ b/tests/src/components/Header.tsx
@@ -134,6 +134,7 @@ describe('Header component', () => {
     enzymeWrapper.find('#close-filter-summary-top').simulate('click', { preventDefault(){}, stopPropagation(){}});
     enzymeWrapper.find('#close-filter-summary-bottom').simulate('click', { preventDefault(){}, stopPropagation(){}});
     expect(focusToggleSummarySpy).toBeCalledTimes(2);
+    focusToggleSummarySpy.mockRestore();
   });
 
   it('should map state to props', () => {

--- a/tests/src/components/Panel.tsx
+++ b/tests/src/components/Panel.tsx
@@ -106,11 +106,30 @@ describe('Panel component', () => {
                                                                     target: panelMock,
                                                                     key: ' ', keyCode: 32, which: 32 })
     // Pressing enter on a link inside panel shouldn't toggle collapse
-    const linkInsidePanelMock = document.createElement('a');
+    const linkInPanelMock = document.createElement('a');
     enzymeWrapper.find('.sk-panel__container').simulate('keydown', { preventDefault(){}, stopPropagation(){},
-                                                                    target: linkInsidePanelMock,
+                                                                    target: linkInPanelMock,
                                                                     key: 'Enter', keyCode: 13, which: 13 })
+    // Pressing space on an element inside content part shouldn't toggle collapse
+    const contentMock = document.createElement('div');
+    contentMock.classList.add('sk-panel__content');
+    const inputInContentMock = document.createElement('input');
+    contentMock.appendChild(inputInContentMock);
+    // Mock document.querySelectorAll so that it will return an element when looking for .sk-panel__content
+    const originalQuerySelectorAll = document.querySelectorAll;
+    const mockQuerySelectorAll = jest.fn((selector: string) => {
+      if (selector === '.sk-panel__content') {
+        return [contentMock] as unknown as NodeListOf<HTMLElement>;
+      }
+      return [] as unknown as NodeListOf<HTMLElement>;
+    });
+    document.querySelectorAll = mockQuerySelectorAll;
+    enzymeWrapper.find('.sk-panel__container').simulate('keydown', { preventDefault(){}, stopPropagation(){},
+                                                                    target: inputInContentMock,
+                                                                    key: ' ', keyCode: 32, which: 32 })
+    document.querySelectorAll = originalQuerySelectorAll;
     expect(toggleCollapsedSpy).toBeCalledTimes(2);
+    toggleCollapsedSpy.mockRestore();
   });
 
   it('should map state to props', () => {

--- a/tests/src/components/Result.tsx
+++ b/tests/src/components/Result.tsx
@@ -138,6 +138,7 @@ describe('Result component', () => {
                                                                 key: ' ', keyCode: 32, which: 32 },
                                                               'Study title')
     expect(handleAbstractExpansionSpy).toBeCalledTimes(2);
+    handleAbstractExpansionSpy.mockRestore();
   });
 
   it('should change language', () => {

--- a/tests/src/components/Tooltip.tsx
+++ b/tests/src/components/Tooltip.tsx
@@ -65,6 +65,7 @@ describe('Tooltip component', () => {
     enzymeWrapper.find('.button').simulate('keydown', { preventDefault(){}, stopPropagation(){},
                                                         key: 'Escape', keyCode: 27, which: 27 })
     expect(useRefSpy).toBeCalledTimes(1);
+    useRefSpy.mockRestore();
   });
 
   it('should be closed after pressing escape', () => {


### PR DESCRIPTION
Checks that target element isn't in content part of Panel before toggling collapsed so no need to exclude them separately. I'm pretty sure just excluding 'input' would have also worked in the current state but better to not have to worry that I missed something else.

Also added some calls of mockRestore in tests that I realized I hadn't added previously when using jest.spyOn.