### PR TITLE
Use the CESSDA Nexus repository to proxy NPM content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM node:20 AS build
 
 # Create app directory
 WORKDIR /usr/src/app
+COPY .npmrc ./
 COPY package*.json ./
 
 # NodeJS Install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,14 @@ pipeline {
 	}
 
 	stages {
-		stage('Configure Node.JS environment') {
+		stage('Install NPM dependencies') {
+			steps {
+				configFileProvider([configFile(fileId: 'be684558-5540-4ad6-a155-7c1b4278abc0', targetLocation: '.npmrc')]) {
+					sh 'docker build --target build .'
+				}
+			}
+		}
+		stage('Configure Node.JS test environment') {
 			agent {
 				dockerfile {
 					additionalBuildArgs '--target build'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/jest": "29.5.1",
     "@types/jquery": "3.5.16",
     "@types/method-override": "0.0.32",
-    "@types/mini-css-extract-plugin": "2.5.1",
     "@types/node": "20.6.0",
     "@types/node-fetch": "2.6.2",
     "@types/prop-types": "15.7.5",


### PR DESCRIPTION
By proxying and caching NPM content, the build performance can be improved and the amount of data that needs to be downloaded from NPM can be reduced.