### PR TITLE
#415: Changes to results list: shorten abstract and add randomly chosen keywords below

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -47,8 +47,10 @@ export interface CMMStudy {
   /** Abstract */
   abstract: string;
   abstractShort: string;
+  abstractLong: string;
   abstractHighlight: string;
   abstractHighlightShort: string;
+  abstractHighlightLong: string;
   /** Study title */
   titleStudy: string;
   titleStudyHighlight: string;
@@ -141,9 +143,11 @@ export function getStudyModel(source: Partial<CMMStudy> | undefined, highlight?:
     creators: source.creators || [],
     pidStudies: source.pidStudies || [],
     abstract: stripHTMLElements(source.abstract as string),
-    abstractShort: truncateAbstract(striptags(source.abstract as string)),
+    abstractShort: truncateAbstract(striptags(source.abstract as string), 380),
+    abstractLong: truncateAbstract(striptags(source.abstract as string), 2000),
     abstractHighlight: highlight?.abstract ? stripHTMLElements(highlight.abstract.join()) : '',
-    abstractHighlightShort: highlight?.abstract ? truncateAbstract(striptags(highlight.abstract.join())) : '',
+    abstractHighlightShort: highlight?.abstract ? truncateAbstract(striptags(highlight.abstract.join()), 380) : '',
+    abstractHighlightLong: highlight?.abstract ? truncateAbstract(striptags(highlight.abstract.join()), 2000) : '',
     studyAreaCountries: source.studyAreaCountries || [],
     typeOfTimeMethods: source.typeOfTimeMethods || [],
     unitTypes: source.unitTypes || [],
@@ -171,9 +175,9 @@ export function getStudyModel(source: Partial<CMMStudy> | undefined, highlight?:
   });
 }
 
-function truncateAbstract(string: string): string {
+function truncateAbstract(string: string, limit: number): string {
   const trimmedString = string.trim();
-  return truncate(trimmedString, { length: 500, separator: ' ' } );
+  return truncate(trimmedString, { length: limit, separator: ' ' } );
 }
 
 /**

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -37,6 +37,7 @@ export interface State {
 export default class Detail extends React.Component<Props, State> {
 
   private static readonly truncatedAbstractLength = 2000;
+  private static readonly truncatedKeywordsLength = 12;
 
   constructor(props: Props) {
     super(props);
@@ -246,7 +247,7 @@ Summary information
           {this.state.abstractExpanded ?
             <div className="data-abstract" lang={lang} dangerouslySetInnerHTML={{ __html: item.abstract }}/>
           :
-            <div className="data-abstract" lang={lang}>{truncate(striptags(item.abstract), { length: Detail.truncatedAbstractLength, separator: ' ' })}</div>
+            <div className="data-abstract" lang={lang} dangerouslySetInnerHTML={{ __html: item.abstractLong }}/>
           }
           {item.abstract.length > Detail.truncatedAbstractLength &&
             <a className="button is-small is-white" onClick={() => {
@@ -294,7 +295,7 @@ Summary information
                             ariaLabel={counterpart.translate("metadata.keywords.tooltip.ariaLabel")}/>}
           collapsable={false}
         >
-          <Keywords keywords={item.keywords} lang={this.props.lang}/>
+          <Keywords keywords={item.keywords} keywordLimit={Detail.truncatedKeywordsLength} lang={this.props.lang}/>
         </Panel>
 
         <Panel

--- a/src/components/Keywords.tsx
+++ b/src/components/Keywords.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from "react";
-import { Link } from "react-router";
+import React, { createRef } from "react";
+import { Link, browserHistory } from "react-router";
 import { TermVocabAttributes } from "../../common/metadata";
 import { upperFirst } from "lodash";
 import Translate from "react-translate-component";
@@ -22,6 +22,8 @@ import { TermURIResult, getELSSTTerm } from "../utilities/elsst";
 export interface Props {
   keywords: TermVocabAttributes[];
   lang: string;
+  keywordLimit: number;
+  isExpandDisabled?: boolean;
 }
 
 interface State {
@@ -31,12 +33,12 @@ interface State {
 
 export default class Keywords extends React.Component<Props, State> {
 
-  private static readonly truncatedKeywordsLength = 12;
+  private controllerRef = createRef<AbortController>();
 
   constructor(props: Props) {
     super(props);
     this.state = {
-      isExpanded: !(props.keywords.length > Keywords.truncatedKeywordsLength),
+      isExpanded: !(props.keywords.length > props.keywordLimit),
       elsstURLs: {}
     };
   }
@@ -47,8 +49,15 @@ export default class Keywords extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Readonly<Props>): void {
     if (this.props.keywords !== prevProps.keywords) {
+      this.setState({
+        isExpanded: !(this.props.keywords.length > this.props.keywordLimit),
+      });
       this.getELSSTURLs(this.props.keywords);
     }
+  }
+
+  componentWillUnmount(): void {
+    this.controllerRef.current && this.controllerRef.current.abort();
   }
 
   private generateElements<T> (
@@ -71,10 +80,12 @@ export default class Keywords extends React.Component<Props, State> {
   }
 
   private async getELSSTURLs(keywords: TermVocabAttributes[]) {
-    const elsstTerms = keywords.map(k => k.term);
-    const elsstURLs = await getELSSTTerm(elsstTerms, this.props.lang);
+    (this.controllerRef as React.MutableRefObject<AbortController>).current = new AbortController();
+    // Only get ELSST terms for shown keywords if expanding is disabled
+    const elsstTerms = this.props.isExpandDisabled ? keywords.slice(0, this.props.keywordLimit).map(k => k.term) : keywords.map(k => k.term);
+    const elsstURLs = await getELSSTTerm(elsstTerms, this.props.lang, this.controllerRef.current!.signal);
 
-    this.setState({
+    !this.controllerRef.current!.signal.aborted && this.setState({
       elsstURLs: elsstURLs
     });
   }
@@ -82,12 +93,17 @@ export default class Keywords extends React.Component<Props, State> {
   render(): React.ReactNode {
     return (<>
       <div className="tags">
-        {this.generateElements(this.state.isExpanded ? this.props.keywords : this.props.keywords.slice(0, 12),
+        {this.generateElements(this.state.isExpanded ? this.props.keywords : this.props.keywords.slice(0, this.props.keywordLimit),
           keywords => {
             // If the term is a valid ELSST term, also link to ELSST
             const keywordTerm = upperFirst(keywords.term);
+            // state.requireRefresh is used in App to update key so page gets updated even when location is the same
+            const keywordLinkTo = browserHistory.getCurrentLocation().pathname === "/" ?
+              {pathname: '/', search: `?keywords.term[0]=${encodeURI(keywords.term)}`, state: {requireRefresh: true}}
+              :
+              {pathname: '/', search: `?keywords.term[0]=${encodeURI(keywords.term)}`};
             return (<>
-              <Link to={`/?keywords.term[0]=${encodeURI(keywords.term)}`}>{keywordTerm}</Link>
+              <Link to={keywordLinkTo}>{keywordTerm}</Link>
               {this.state.elsstURLs[keywords.term] &&
                 <span className="is-inline-flex is-align-items-center">&nbsp;(
                   <a href={this.state.elsstURLs[keywords.term]} rel="noreferrer" target="_blank"
@@ -99,8 +115,15 @@ export default class Keywords extends React.Component<Props, State> {
             </>)
           }
         )}
+        {this.props.isExpandDisabled && this.props.keywords.length > this.props.keywordLimit &&
+          <span className="tag">
+            <span>&nbsp;({this.props.keywords.length - this.props.keywordLimit}&nbsp;</span>
+            <Translate component="span" content="more" />
+            <span>)</span>
+          </span>
+        }
       </div>
-      {this.props.keywords.length > Keywords.truncatedKeywordsLength &&
+      {!this.props.isExpandDisabled && this.props.keywords.length > this.props.keywordLimit &&
         <a className="button is-small is-white" onClick={() =>
           // Toggle the expanded state
           this.setState(state => ({ isExpanded: !state.isExpanded }))

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -56,7 +56,7 @@ function generateCreatorElements(item: CMMStudy) {
 }
 
 // Randomize array using Durstenfeld shuffle algorithm
-function shuffleArray(array: Array<any>) {
+function shuffleArray<T>(array: Array<T>) {
   if (array) {
     for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -20,8 +20,9 @@ import { Link } from 'react-router';
 import type { State } from '../types';
 import { changeLanguage } from '../actions/language';
 import { push } from 'react-router-redux';
-import { CMMStudy } from '../../common/metadata';
+import { CMMStudy, TermVocabAttributes } from '../../common/metadata';
 import getPaq from '../utilities/getPaq';
+import Keywords from './Keywords';
 
 type Props = {
   bemBlocks: any;
@@ -32,6 +33,7 @@ type Props = {
 
 interface ComponentState {
   abstractExpanded: boolean;
+  shuffledKeywords: TermVocabAttributes[];
 }
 
 function generateCreatorElements(item: CMMStudy) {
@@ -53,7 +55,28 @@ function generateCreatorElements(item: CMMStudy) {
   return creators;
 }
 
+// Randomize array using Durstenfeld shuffle algorithm
+function shuffleArray(array: Array<any>) {
+  if (array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+  }
+  return array;
+}
+
 export class Result extends Component<Props, ComponentState> {
+
+  private static readonly truncatedKeywordsLength = 7;
+
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (this.props.item && (!prevProps.item || this.props.item.keywords !== prevProps.item.keywords)) {
+      this.setState({
+        shuffledKeywords: shuffleArray(this.props.item.keywords)
+      });
+    }
+  }
 
   handleKeyDown(event: React.KeyboardEvent, titleStudy: string) {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -76,7 +99,8 @@ export class Result extends Component<Props, ComponentState> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      abstractExpanded: false
+      abstractExpanded: false,
+      shuffledKeywords: props.item ? shuffleArray(props.item.keywords) : []
     };
   }
 
@@ -127,14 +151,18 @@ export class Result extends Component<Props, ComponentState> {
         </div>
         <div className={bemBlocks.item().mix(bemBlocks.container('desc'))} lang={currentLanguage}>
           {this.state.abstractExpanded ? 
-            <span className="abstr" dangerouslySetInnerHTML={{__html: item.abstractHighlight || item.abstract}}/>
+            <span dangerouslySetInnerHTML={{__html: item.abstractHighlightLong || item.abstractLong}}/>
           :
             <span dangerouslySetInnerHTML={{__html: item.abstractHighlightShort || item.abstractShort}}/>
           }
         </div>
+        <div className="is-flex mt-10">
+          <Keywords keywords={this.state.shuffledKeywords} keywordLimit={Result.truncatedKeywordsLength}
+                    lang={currentLanguage} isExpandDisabled={true}/>
+        </div>
         <div className="result-actions mt-10">
           <div className="is-flex is-hidden-touch">
-            {item.abstract.length > 500 &&
+            {item.abstract.length > 380 &&
               <a className={bemBlocks.item().mix('button is-small is-white focus-visible')} tabIndex={0}
                 onClick={() => this.handleAbstractExpansion(item.titleStudy)}
                 onKeyDown={(e) => this.handleKeyDown(e, item.titleStudy)}>

--- a/src/containers/App.ts
+++ b/src/containers/App.ts
@@ -11,13 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component } from "react";
+import { Component, cloneElement } from "react";
 import { AnyAction, bindActionCreators } from "redux";
 import { connect, Dispatch } from "react-redux";
 import { initSearchkit, updateTotalStudies } from "../actions/search";
 import { initTranslations } from "../actions/language";
 
-interface Props extends ReturnType<typeof mapDispatchToProps> {
+export interface Props extends ReturnType<typeof mapDispatchToProps> {
+  location: {
+    key: string;
+    state?: {
+      requireRefresh?: boolean;
+    };
+  };
   children: JSX.Element
 }
 
@@ -31,7 +37,13 @@ export class App extends Component<Props> {
   }
 
   render() {
-    return this.props.children;
+    // state.requireRefresh is used to make sure page gets updated when location is the same by
+    // adding an updated key for search page (otherwise undefined), e.g. clicking on keywords in search results
+    if(this.props.location.state && this.props.location.state.requireRefresh){
+      return cloneElement(this.props.children, { key: this.props.location.key });
+    } else {
+      return this.props.children;
+    }
   }
 }
 

--- a/src/utilities/elsst.ts
+++ b/src/utilities/elsst.ts
@@ -13,7 +13,7 @@
 
 export interface TermURIResult extends Record<string, string> {}
 
-export async function getELSSTTerm(labels: string[], lang: string): Promise<TermURIResult> {
+export async function getELSSTTerm(labels: string[], lang: string, signal: AbortSignal): Promise<TermURIResult> {
   // Only send a request if the list of labels is not empty
   if (labels.length === 0) {
     return {};
@@ -25,17 +25,25 @@ export async function getELSSTTerm(labels: string[], lang: string): Promise<Term
   };
 
   // Request term from ELSST, the label is encoded
-  const response = await fetch(`${window.location.origin}/api/elsst/_terms`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify(body)
-  });
+  try {
+    const response = await fetch(`${window.location.origin}/api/elsst/_terms`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body),
+      signal
+    });
 
-  // Match potentially found - try to extract the URI
-  if (response.ok) {
-    return await response.json() as TermURIResult;
+    // Match potentially found - try to extract the URI
+    if (response.ok) {
+      return await response.json() as TermURIResult;
+    }
+  } catch (error) {
+    // Fetch was aborted
+    if (error instanceof DOMException && error.message === 'The user aborted a request.'){
+      return {};
+    }
   }
 
   // Response not OK

--- a/src/utilities/elsst.ts
+++ b/src/utilities/elsst.ts
@@ -40,9 +40,11 @@ export async function getELSSTTerm(labels: string[], lang: string, signal: Abort
       return await response.json() as TermURIResult;
     }
   } catch (error) {
-    // Fetch was aborted
+    // Log error on debug level if it was because the fetch got aborted
     if (error instanceof DOMException && error.message === 'The user aborted a request.'){
-      return {};
+      console.debug(`ELSST term fetching was aborted (${error})`);
+    } else {
+      console.log(`Error while fetching ELSST terms: ${error}`);
     }
   }
 

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -23,8 +23,10 @@ describe('Metadata utilities', () => {
           titleStudyHighlight: 'Study Title',
           abstract: 'Abstract',
           abstractShort: 'Abstract',
+          abstractLong: 'Abstract',
           abstractHighlight: 'Abstract',
           abstractHighlightShort: 'Abstract',
+          abstractHighlightLong: 'Abstract',
           classifications: [
             {
               id: 'UKDS1234',
@@ -111,8 +113,10 @@ describe('Metadata utilities', () => {
         titleStudyHighlight: '',
         abstract: 'Abstract',
         abstractShort: 'Abstract',
+        abstractLong: 'Abstract',
         abstractHighlight: '',
         abstractHighlightShort: '',
+        abstractHighlightLong: '',
         classifications: [
           {
             id: 'UKDS1234',
@@ -207,8 +211,10 @@ describe('Metadata utilities', () => {
         titleStudyHighlight: '',
         abstract: '',
         abstractShort: '',
+        abstractLong: '',
         abstractHighlight: '',
         abstractHighlightShort: '',
+        abstractHighlightLong: '',
         classifications: [],
         code: undefined,
         creators: [],
@@ -258,6 +264,8 @@ describe('Metadata utilities', () => {
           abstractHighlight: '',
           abstractShort: 'Abstract',
           abstractHighlightShort: '',
+          abstractLong: 'Abstract',
+          abstractHighlightLong: '',
           classifications: [
             {
               id: 'UKDS1234',
@@ -395,6 +403,8 @@ describe('Metadata utilities', () => {
           abstractHighlight: '',
           abstractShort: 'Abstract',
           abstractHighlightShort: '',
+          abstractLong: 'Abstract',
+          abstractHighlightLong: '',
           classifications: [
             {
               id: 'UKDS1234',

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -7,7 +7,9 @@ export const mockStudy: CMMStudy = {
   abstract: 'This is a mock abstract describing a mock study.\n\nThe key results of this mock study is providing mock data that can be used to validate proper functionality of the application.',
   abstractHighlight: '',
   abstractShort: 'Abstract',
+  abstractLong: 'Abstract',
   abstractHighlightShort: '',
+  abstractHighlightLong: '',
   classifications: [
     {
       id: 'UKDS1234',

--- a/tests/src/components/Keywords.tsx
+++ b/tests/src/components/Keywords.tsx
@@ -17,6 +17,7 @@ import Keywords, { Props } from '../../../src/components/Keywords';
 import { TermVocabAttributes } from '../../../common/metadata';
 import { getELSSTTerm } from '../../../src/utilities/elsst';
 import { TermURIResult } from '../../../server/elsst';
+import { Link, browserHistory } from 'react-router';
 
 // Mock out the module that sends requests to the server
 jest.mock('../../../src/utilities/elsst.ts', () => {
@@ -31,6 +32,7 @@ function setup(providedProps: Partial<Props> = {}) {
   const props: Props = {
     keywords: [],
     lang: "en",
+    keywordLimit: 12,
     ...providedProps
   };
   const enzymeWrapper = shallow(<Keywords {...props} />);
@@ -70,7 +72,7 @@ describe('Keywords component', () => {
     expect(tagElements).toHaveLength(4);
 
     // When rendering the component should have requested ELSST terms for the keywords
-    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang);
+    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang, expect.anything());
   });
 
   it('should update keywords', () => {
@@ -81,17 +83,18 @@ describe('Keywords component', () => {
     });
 
     // When rendering the component should have requested ELSST terms for the keywords
-    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang);
+    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang, expect.anything());
 
     // Update keywords
     const newKeywords = ["5", "6", "7", "8"];
-    enzymeWrapper.setProps({ keywords: newKeywords.map(t => getKeyword(t)) })
+    enzymeWrapper.setProps({ keywords: newKeywords.map(t => getKeyword(t)) });
+    enzymeWrapper.update();
 
     // ELSST terms should be requested for the new keywords
-    expect(getELSSTTerm).toHaveBeenCalledWith(newKeywords, props.lang);
+    expect(getELSSTTerm).toHaveBeenCalledWith(newKeywords, props.lang, expect.anything());
   });
 
-  it('should link ELSST terms', async () => {
+  it('should link ELSST terms and limit fetching according to given keyword limit when expanding is disabled', async () => {
     const linkELSST = "https://elsst.cessda.eu/test/";
 
     let promise: Promise<TermURIResult> = Promise.resolve({});
@@ -113,17 +116,20 @@ describe('Keywords component', () => {
       return promise;
     });
 
-    const keywords = ["1", "2", "3", "4"];
+    const keywords = ["1", "2", "3", "4", "5", "6", "7"];
 
     const { enzymeWrapper, props } = setup({
-      keywords: keywords.map(t => getKeyword(t))
+      keywords: keywords.map(t => getKeyword(t)),
+      keywordLimit: 4,
+      isExpandDisabled: true
     });
 
     // Wait for the promise to be resolved
     await promise;
 
     // When rendering the component should have requested ELSST terms for the keywords
-    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang);
+    // It should also only request term for the first 4 keywords because of keyword limit and disabled expanding
+    expect(getELSSTTerm).toHaveBeenCalledWith(["1", "2", "3", "4"], props.lang, expect.anything());
 
     // The terms with ELSST link provided should link to ELSST
     const tagsELSSTFound = enzymeWrapper.find(".tag").map((tagElement) => {
@@ -134,7 +140,8 @@ describe('Keywords component', () => {
       }
       return false;
     });
-    expect(tagsELSSTFound).toEqual([true, true, false, true]);
+    // Limit is 4 but 5 elements are found because 'x more' also has .tag class
+    expect(tagsELSSTFound).toEqual([true, true, false, true, false]);
   });
 
   it('should toggle between showing limited number of keywords and showing all keywords', () => {
@@ -152,5 +159,36 @@ describe('Keywords component', () => {
     enzymeWrapper.find('.button').at(0).simulate('click');
     expect(enzymeWrapper.state('isExpanded')).toBe(true);
     expect(enzymeWrapper.find(".tag")).toHaveLength(15);
+  });
+
+  it('should abort ELSST term fetch when unmounting', () => {
+    const keywords = ["1", "2", "3", "4"];
+
+    const { enzymeWrapper, props } = setup({
+      keywords: keywords.map(t => getKeyword(t))
+    });
+
+    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+
+    enzymeWrapper.unmount();
+
+    expect(abortSpy).toBeCalledTimes(1);
+    abortSpy.mockRestore();
+  });
+
+  it('should have different search page link props depending on location', () => {
+    const keywords = ["1"];
+
+    // Location already on search page should include variable to require refresh
+    browserHistory.push("/");
+    const { enzymeWrapper, props } = setup({
+      keywords: keywords.map(t => getKeyword(t))
+    });
+    expect(enzymeWrapper.find(Link).props().to).toEqual({pathname: '/', search: `?keywords.term[0]=1`, state: {requireRefresh: true}});
+
+    // Location not on search page should not include variable to require refresh
+    browserHistory.push("/detail");
+    enzymeWrapper.setProps({props})
+    expect(enzymeWrapper.find(Link).props().to).toEqual({pathname: '/', search: `?keywords.term[0]=1`});
   });
 });

--- a/tests/src/components/Result.tsx
+++ b/tests/src/components/Result.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../src/components/Result';
 import { CMMStudy } from '../../../common/metadata';
 import { Language, languages } from '../../../src/utilities/language';
+import Keywords from '../../../src/components/Keywords';
 
 // Mock props and shallow render component for test.
 function setup(item?: Partial<CMMStudy> | false) {
@@ -38,18 +39,21 @@ function setup(item?: Partial<CMMStudy> | false) {
             {
               id: 1,
               titleStudy: 'Study Title',
-              abstract: "Long Abstract.\nAipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed augue lacus.",
+              abstract: "Full Abstract.\nAipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed augue lacus.",
               abstractExpanded: false,
               abstractShort: 'Short Abstract',
-              abstractHighlight: 'Long Abstract highlighted',
+              abstractLong: 'Long Abstract',
+              abstractHighlight: 'Full Abstract highlighted',
               abstractHighlightShort: 'Short abstract highlighted',
+              abstractHighlightLong: 'Long abstract highlighted',
               creators: [
                 'Jane Doe',
                 'University of Essex',
                 'John Smith (University of Essex)'
               ],
               langAvailableIn: ['EN'],
-              studyUrl: 'http://example.com'
+              studyUrl: 'http://example.com',
+              keywords: ["1", "2", "3", "4"]
             },
             item || {}
           ),
@@ -150,6 +154,24 @@ describe('Result component', () => {
       .at(2)
       .simulate('click');
     expect(props.changeLanguage).toHaveBeenCalled();
+  });
+
+  it('should shuffle keywords and reshuffle if keywords change', () => {
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.2);
+
+    const { props, enzymeWrapper } = setup();
+    expect(enzymeWrapper.find(Keywords).props().keywords).toEqual(["2", "3", "4", "1"]);
+
+    // Props updated but keywords didn't change so don't reshuffle
+    enzymeWrapper.setProps({props})
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
+    expect(enzymeWrapper.find(Keywords).props().keywords).toEqual(["2", "3", "4", "1"]);
+
+    // Props updated and keywords changed so reshuffle
+    enzymeWrapper.setProps({...props, item: {...props.item, keywords: ["6", "5", "4", "3", "2", "1"]}})
+    expect(enzymeWrapper.find(Keywords).props().keywords).toEqual(["6", "5", "4", "3", "1", "2"]);
+
+    jest.spyOn(global.Math, 'random').mockRestore();
   });
 
   it('should map state to props', () => {

--- a/tests/src/containers/App.tsx
+++ b/tests/src/containers/App.tsx
@@ -13,15 +13,20 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { App, mapDispatchToProps } from '../../../src/containers/App';
+import { App, Props, mapDispatchToProps } from '../../../src/containers/App';
 
 // Mock props and shallow render container for test.
-function setup() {
+function setup(providedProps: Partial<Props> = {}) {
   const props = {
     initSearchkit: jest.fn(),
     initTranslations: jest.fn(),
     updateTotalStudies: jest.fn(),
-    children: <div/>
+    location: {
+      key: 'key',
+      state: {}
+    },
+    children: <div key={undefined}/>,
+    ...providedProps
   };
   const enzymeWrapper = shallow(<App {...props} />);
   return {
@@ -34,6 +39,13 @@ describe('App container', () => {
   it('should render', () => {
     const { enzymeWrapper } = setup();
     expect(enzymeWrapper.exists()).toBe(true);
+  });
+
+  it('should add key to children (search page) if page is required to refresh via location state variable', () => {
+    const { enzymeWrapper, props } = setup({
+      location: {key: 'newkey', state: {requireRefresh: true}}
+    });
+    expect(enzymeWrapper.find('div').key()).toEqual('newkey');
   });
 
   it('should map dispatch to props', () => {

--- a/translations/en.json
+++ b/translations/en.json
@@ -152,6 +152,7 @@
   "sortBy": "Sort by",
   "showFilters": "Show filters",
   "hideFilters": "Hide filters",
+  "more": "more",
   "readMore": "Read more",
   "readLess": "Read less",
   "viewJson": "View JSON",


### PR DESCRIPTION
These results list changes required some other changes for everything to work correctly.

- App can update <code>key</code> of children (<code>SearchPage</code>) to update page even if location didn't change
- <code>AbortController</code> for ELSST term fetching in <code>Keywords</code> in case user navigates while fetch is still going
- <code>Keywords</code> always requires <code>keywordLimit</code> parameter to keep the code simple