### PR TITLE
#611: Fix overflow and underflow issues, adjust responsive placement …

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -156,10 +156,12 @@ export class Result extends Component<Props, ComponentState> {
             <span dangerouslySetInnerHTML={{__html: item.abstractHighlightShort || item.abstractShort}}/>
           }
         </div>
-        <div className="is-flex mt-10">
-          <Keywords keywords={this.state.shuffledKeywords} keywordLimit={Result.truncatedKeywordsLength}
-                    lang={currentLanguage} isExpandDisabled={true}/>
-        </div>
+        {this.state.shuffledKeywords.length > 0 &&
+          <div className="is-flex mt-10">
+            <Keywords keywords={this.state.shuffledKeywords} keywordLimit={Result.truncatedKeywordsLength}
+                      lang={currentLanguage} isExpandDisabled={true}/>
+          </div>
+        }
         <div className="result-actions mt-10">
           <div className="is-flex is-hidden-touch">
             {item.abstract.length > 380 &&
@@ -180,7 +182,7 @@ export class Result extends Component<Props, ComponentState> {
               </a>
             }
           </div>
-          <div className="is-flex">
+          <div className="is-flex is-flex-wrap-wrap">
             {languages.length > 0 &&
               <div className="buttons has-addons">
                 <span className="button is-small is-white bg-w pe-none">

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -3,6 +3,11 @@
   padding:0 !important;
 }
 
+html, body, #root {
+  min-height: 100%;
+  height: 100%;
+}
+
 body {
   min-width: auto;
   text-align: left;
@@ -22,6 +27,9 @@ body {
   }
 
   .sk-layout {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
     background-color: $white;
 
     a {
@@ -267,8 +275,12 @@ padding: 6px 0;
     display: initial;
   }
 
-  .sk-panel__content .Select-aria-only {
-    display: none;
+  .sk-panel__content {
+    word-wrap: break-word;
+
+    .Select-aria-only {
+      display: none;
+    }
   }
 
  .Select-clear-zone {
@@ -296,8 +308,12 @@ padding: 6px 0;
   display: flex;
   justify-content: space-between;
 
-  .is-flex .buttons {
-    margin-bottom: -0.5rem !important;
+  .is-flex .buttons:not(:last-child) {
+    margin-bottom: 0 !important;
+  }
+
+  .is-flex .buttons .button {
+    margin-bottom: 0 !important;
   }
 
   @include touch {

--- a/src/styles/modules/_layout.scss
+++ b/src/styles/modules/_layout.scss
@@ -3,6 +3,7 @@
 }
 
 .sk-layout__filters, .sk-layout__results {
+  max-width: 100%;
   margin: 0;
   padding: 0.75rem 0.75rem;
   @extend .column;

--- a/src/styles/modules/_mobile.scss
+++ b/src/styles/modules/_mobile.scss
@@ -60,6 +60,10 @@ body {
 }
 
 @media screen and (max-width: 768px) {
+  .container {
+    max-width: 100%;
+  }
+
   header {
     background-size: 100% !important;
   }
@@ -102,6 +106,10 @@ body {
   }
 
   .show-mobile-filters {
+    .container {
+      min-width: 100%;
+    }
+
     .sk-layout__body {
       position: relative;
     }


### PR DESCRIPTION
…of buttons on result, check that keywords exist for result before adding an element for them


I realized that keywords was showing "Not available" on result list if there wasn't any for the study and I don't think it's needed. Especially because it doesn't actually tell what is not available since there's no "Keywords" text on result list like there is on detail view. Now there is a check so "Not available" doesn't show up on result list when there's no keywords.

Fixing the underflow, e.g. looking at About page on a large screen, required setting quite a few min-height and height in addition to making .sk-layout also flex so it then required some additional changes to fix some elements that got broken like selected filters on mobile. I don't think I missed any but I can't really check all kinds of browsers and devices so hopefully there aren't any that would behave very differently with these changes.