### PR TITLE
Simplify the handling of the AbortController in the Keywords component

### DIFF
--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -17,7 +17,7 @@ import { Link } from "react-router";
 import Tooltip from './Tooltip';
 import Panel from "./Panel";
 import Translate from "react-translate-component";
-import { truncate, upperFirst } from "lodash";
+import { upperFirst } from "lodash";
 import { CMMStudy, DataCollectionFreeText, Universe } from "../../common/metadata";
 import { ChronoField, DateTimeFormatter, DateTimeFormatterBuilder } from "@js-joda/core";
 import { FaAngleDown, FaAngleUp } from "react-icons/fa";

--- a/src/utilities/elsst.ts
+++ b/src/utilities/elsst.ts
@@ -41,7 +41,7 @@ export async function getELSSTTerm(labels: string[], lang: string, signal: Abort
     }
   } catch (error) {
     // Log error on debug level if it was because the fetch got aborted
-    if (error instanceof DOMException && error.message === 'The user aborted a request.'){
+    if (signal.aborted){
       console.debug(`ELSST term fetching was aborted (${error})`);
     } else {
       console.log(`Error while fetching ELSST terms: ${error}`);


### PR DESCRIPTION
Using a `ref` is unnecessary, simply having a plain `AbortController` that lasts the lifetime of the components mount is clearer. This also avoids having to use the null-forgiveness operator `!`.