### PR TITLE
Remove the "bodybuilder" NPM dependency and construct Elasticsearch requests directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@elastic/elasticsearch": "8.13.0",
         "body-parser": "1.20.2",
-        "bodybuilder": "2.5.0",
         "compression": "1.7.4",
         "cors": "2.8.5",
         "detect-browser": "5.3.0",
@@ -6329,19 +6328,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/bodybuilder": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bodybuilder/-/bodybuilder-2.5.0.tgz",
-      "integrity": "sha512-n9Cpi/qKH7FfFe3WHRC/jYBQt/vtkPmCuDdIM53lARoWHVDGEc5d55erKZE/dxzv0dY+ioKcd+C8EY+AytBlSw==",
-      "dependencies": {
-        "lodash.clonedeep": "4.5.0",
-        "lodash.isobject": "3.0.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.merge": "4.6.2",
-        "lodash.set": "4.3.2",
-        "lodash.unset": "4.5.2"
       }
     },
     "node_modules/boolbase": {
@@ -12886,7 +12872,9 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12912,15 +12900,11 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -12931,17 +12915,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
-    },
-    "node_modules/lodash.unset": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
-      "integrity": "sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/logform": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@elastic/elasticsearch": "8.13.0",
     "body-parser": "1.20.2",
-    "bodybuilder": "2.5.0",
     "compression": "1.7.4",
     "cors": "2.8.5",
     "detect-browser": "5.3.0",

--- a/server/elasticsearch.ts
+++ b/server/elasticsearch.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { Client, ClientOptions } from '@elastic/elasticsearch'
-import { 
+import {
   AggregationsCardinalityAggregate,
   AggregationsNestedAggregate,
   AggregationsStringTermsAggregate,
@@ -79,7 +79,7 @@ export default class Elasticsearch {
       size: 0,
       index: `${this.indexName}_*`,
       query: { match_all: {} },
-      aggs: { 
+      aggs: {
         unique_id: {
           cardinality: {
             field: "id"
@@ -96,7 +96,7 @@ export default class Elasticsearch {
   async getListOfMetadataLanguages() {
     const res = await this.client.indices.get({
       allow_no_indices: true,
-      index: `${this.indexName}_*` 
+      index: `${this.indexName}_*`
     });
     const indices = Object.keys(res);
 
@@ -128,7 +128,7 @@ export default class Elasticsearch {
     // Unwrap the aggregations
     const aggregation = res.aggregations?.publishers as AggregationsNestedAggregate;
     const publisherBuckets = (aggregation.publisher as AggregationsStringTermsAggregate).buckets;
-    
+
     if (Array.isArray(publisherBuckets)) {
       return publisherBuckets.map(b => b.key);
     } else {
@@ -248,9 +248,9 @@ export default class Elasticsearch {
    * @param lang the language of the records.
    */
   async getRecordCountByLanguage(lang: string): Promise<number | undefined>{
-    const response = await this.client.search({ 
+    const response = await this.client.search({
       index: `cmmstudy_${lang}`,
-      track_total_hits: true 
+      track_total_hits: true
     });
     return Elasticsearch.parseTotalHits(response.hits.total);
   }

--- a/server/elsst.ts
+++ b/server/elsst.ts
@@ -30,7 +30,7 @@ export interface TermURIResult extends Record<string, string> {}
 /**
  * Cache for ELSST terms
  */
-const termCache = new Map<string, string | undefined>();
+const termCache = new Map<string, string | null>();
 
 async function getELSSTTerm(labels: string[], lang: string): Promise<TermURIResult> {
 
@@ -71,7 +71,7 @@ async function getELSSTTerm(labels: string[], lang: string): Promise<TermURIResu
       }
     } else if (response.status === 404) {
       // If a 404 response is returned, the term doesn't exist in ELSST
-      termCache.set(normalisedLabel, undefined);
+      termCache.set(normalisedLabel, null);
     }
 
     // Match not found

--- a/server/helper.ts
+++ b/server/helper.ts
@@ -16,11 +16,9 @@ import path from 'path';
 import _ from 'lodash';
 import proxy from 'express-http-proxy';
 import express, { RequestHandler } from 'express';
-import bodybuilder, { Bodybuilder } from 'bodybuilder';
 import bodyParser from 'body-parser';
 import compression from 'compression';
 import methodOverride from 'method-override';
-import { ParsedQs } from 'qs';
 import responseTime from 'response-time';
 import { CMMStudy, getJsonLd, getStudyModel } from '../common/metadata';
 import { apiResponseTimeHandler, metricsRequestHandler, observeAPIClientIP, uiResponseTimeHandler } from './metrics';
@@ -35,6 +33,7 @@ import fetch, { Request } from 'node-fetch';
 import { Agent } from 'http';
 import IPinfoWrapper, { ApiLimitError } from "node-ipinfo";
 import { getELSSTRouter } from './elsst';
+import { QueryDslBoolQuery, QueryDslNestedQuery, QueryDslQueryContainer, Sort } from '@elastic/elasticsearch/lib/api/types';
 
 
 // Defaults to localhost if unspecified
@@ -268,27 +267,41 @@ function externalApiV2() {
     }
 
     //Prepare body for ElasticSearch
-    const bodyQuery = bodybuilder();
+    let sort: Sort | undefined = undefined;
 
     //Implementing Sorting Options
     switch (sortBy) {
       case undefined: //if no sorting option is provided, sort by default Relevance - as UI
-        bodyQuery.sort('_score', 'desc');
+        sort = {
+          _score: {
+            order: 'desc'
+          }
+        };
         break;
       case "titleAscending":
-        bodyQuery.sort('titleStudy.raw', 'asc');
+        sort = {
+          'titleStudy.raw': 'asc'
+        };
         break;
       case "titleDescending":
-        bodyQuery.sort('titleStudy.raw', 'desc');
+        sort = {
+          'titleStudy.raw': 'desc'
+        };
         break;
       case "dateOfCollectionOldest":
-        bodyQuery.sort('dataCollectionPeriodEnddate', 'asc');
+        sort = {
+          'dataCollectionPeriodEnddate': 'asc'
+        };
         break;
       case "dateOfCollectionNewest":
-        bodyQuery.sort('dataCollectionPeriodEnddate', 'desc');
+        sort = {
+          'dataCollectionPeriodEnddate': 'desc'
+        };
         break;
       case "dateOfPublicationNewest":
-        bodyQuery.sort('publicationYear', 'desc');
+        sort = {
+          publicationYear: 'desc'
+        };
         break;
       default:
         res.status(400).send({ message: 'Please provide a proper sorting option. Available: titleAscending, titleDescending, dateOfCollectionOldest, dateOfCollectionNewest, dateOfPublicationNewest'});
@@ -311,8 +324,6 @@ function externalApiV2() {
       limit = 10;
     }
 
-    bodyQuery.size(limit);
-
     // Validate the offset parameter
     let offset = 0;
     if (req.query.offset !== undefined) {
@@ -320,35 +331,57 @@ function externalApiV2() {
       if (req.query.offset === '' || !Number.isInteger(offset) || offset < 0) {
         res.status(400).send({ message: 'offset must be a positive integer'});
         return;
-      } else {
-        bodyQuery.from(offset);
       }
     }
 
-    //create json body for ElasticSearchClient - search query
-    if (_.isString(q)) {
-      bodyQuery.query('simple_query_string', {
-        query: q,
-        lenient: true,
-        default_operator: "AND",
-        fields: [
-          "titleStudy^4",
-          "abstract^2",
-          "creators^2",
-          "keywords.term^1.5",
-          "*"
-        ],
-        flags: "AND|OR|NOT|PHRASE|PRECEDENCE|PREFIX"
+    // Container for the overall query
+    const boolQuery: QueryDslBoolQuery = {};
+
+    // Holds the main simple_query_string and nested queries
+    const mustQuery: QueryDslQueryContainer[] = [];
+
+    if (req.query.keywords) {
+      // create keywords query
+      mustQuery.push({
+        simple_query_string: {
+          query: (req.query.keywords as string),
+          fields: ["keywordsSearchField"]
+        }
+      });
+    } else if (_.isString(q)) {
+      //create json body for ElasticSearchClient - search query
+      mustQuery.push({
+        simple_query_string: {
+          query: q,
+          lenient: true,
+          default_operator: "AND",
+          fields: [
+            "titleStudy^4",
+            "abstract^2",
+            "creators^2",
+            "keywords.term^1.5",
+            "*"
+          ],
+          flags: "AND|OR|NOT|PHRASE|PRECEDENCE|PREFIX"
+        }
       });
     }
 
     // Create json body for ElasticSearchClient - nested post-filters
-    buildNestedFilters(bodyQuery, req.query.classifications, 'classifications', 'classifications.term');
-    buildNestedFilters(bodyQuery, req.query.studyAreaCountries, 'studyAreaCountries', 'studyAreaCountries.searchField');
-    buildNestedFilters(bodyQuery, req.query.publishers, 'publisherFilter', 'publisherFilter.publisher');
+    if (req.query.classifications) {
+      mustQuery.push({ nested: buildNestedFilters(req.query.classifications, 'classifications', 'classifications.term') });
+    }
 
-    if (req.query.keywords) {
-      bodyQuery.query('simple_query_string', { query: req.query.keywords, fields: ["keywordsSearchField"] });
+    if (req.query.studyAreaCountries) {
+      mustQuery.push({ nested: buildNestedFilters(req.query.studyAreaCountries, 'studyAreaCountries', 'studyAreaCountries.searchField') });
+    }
+
+    if (req.query.publishers) {
+      mustQuery.push({ nested: buildNestedFilters(req.query.publishers, 'publisherFilter', 'publisherFilter.publisher') })
+    }
+
+    if (mustQuery.length > 0) {
+      boolQuery.must = mustQuery;
     }
 
     //Create json body for ElasticSearchClient - date-filters
@@ -361,7 +394,14 @@ function externalApiV2() {
       if (!Number.isInteger(dataCollectionYearMax)) {
         dataCollectionYearMax = undefined;
       }
-      bodyQuery.filter('range', 'dataCollectionYear', { gte: dataCollectionYearMin, lte: dataCollectionYearMax });
+      boolQuery.filter = {
+        range: {
+          dataCollectionYear: {
+            gte: dataCollectionYearMin,
+            lte: dataCollectionYearMax
+          }
+        }
+      };
     }
 
 
@@ -370,8 +410,13 @@ function externalApiV2() {
     try {
       const response = await elasticsearch.client.search<CMMStudy>({
         index: `cmmstudy_${metadataLanguage}`,
-        body: bodyQuery.build(),
-        track_total_hits: true
+        track_total_hits: true,
+        query: {
+          bool: boolQuery
+        },
+        sort: sort,
+        size: limit,
+        from: offset
       });
 
       // Calculate the total hits
@@ -436,14 +481,27 @@ function externalApiV2() {
  * @param path the path to the nested document.
  * @param nestedPath the path to use in the nested document
  */
-function buildNestedFilters(bodyQuery: Bodybuilder, query: string | string[] | ParsedQs | ParsedQs[] | undefined, path: string, nestedPath: string) {
+function buildNestedFilters(query: unknown, path: string, nestedPath: string): QueryDslNestedQuery {
   if (Array.isArray(query)) {
-    bodyQuery.query('nested', { path: path }, (q: Bodybuilder) => {
-      query.forEach(value => q.orQuery('term', nestedPath, value));
-      return q;
-    });
-  } else if (_.isString(query)) {
-    bodyQuery.query('nested', { path: path }, (q: Bodybuilder) => q.addQuery('term', nestedPath, query));
+    return {
+      path: path,
+      query: {
+        terms: {
+          [nestedPath]: query
+        }
+      }
+    };
+  } else {
+    return {
+      path: path,
+      query: {
+        term: {
+          [nestedPath]: {
+            value: query
+          }
+        }
+      }
+    };
   }
 }
 

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -90,15 +90,15 @@
   <div id='root'></div>
   <% if (metadata.jsonLd) { %>
     <script id="json-ld" type="application/ld+json"><%- JSON.stringify(metadata.jsonLd) %></script>
-  <% } %>  
+  <% } %>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
- 
+
   <button id="zammad-feedback-form" class="button is-info">Send feedback</button>
   <script id="zammad_form_script" src="https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js"></script>
   <script>
     $(function() {
       $('#zammad-feedback-form').ZammadForm({
-    agreementMessage:'  Accept CESSDA <a target="_blank" href="https://www.cessda.eu/Privacy-policy">Data Privacy Policy</a> & <a target="_blank" href="https://www.cessda.eu/Acceptable-Use-Policy">Acceptable Use Policy</a>', 
+    agreementMessage:'  Accept CESSDA <a target="_blank" href="https://www.cessda.eu/Privacy-policy">Data Privacy Policy</a> & <a target="_blank" href="https://www.cessda.eu/Acceptable-Use-Policy">Acceptable Use Policy</a>',
     messageTitle: 'CDC Feedback Form',
     messageSubmit: 'Submit',
     messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',

--- a/src/actions/language.ts
+++ b/src/actions/language.ts
@@ -62,7 +62,7 @@ export function initTranslations(): Thunk {
     searchkit.translateFunction = (key: string): string | undefined => {
       const numberOfResults = process.env.PASC_DEBUG_MODE === 'true' ? 'numberOfResultsWithTime' : 'numberOfResults';
       switch (key) {
-        case 'searchbox.placeholder': 
+        case 'searchbox.placeholder':
           return counterpart.translate('search.placeholder');
         case 'hitstats.results_found': {
           const state = getState();
@@ -73,17 +73,17 @@ export function initTranslations(): Thunk {
             time: searchkit.getTime()
           });
         }
-        case 'NoHits.NoResultsFound': 
+        case 'NoHits.NoResultsFound':
           return counterpart.translate('noHits.noResultsFound', {
             query: searchkit.getQueryAccessor().state.value
           });
-        case 'NoHits.SearchWithoutFilters': 
+        case 'NoHits.SearchWithoutFilters':
           return counterpart.translate('noHits.searchWithoutFilters', {
             query: searchkit.getQueryAccessor().state.value
           });
-        case 'NoHits.Error': 
+        case 'NoHits.Error':
           return counterpart.translate('noHits.error');
-        case 'NoHits.ResetSearch': 
+        case 'NoHits.ResetSearch':
           return counterpart.translate('noHits.resetSearch');
         default:
           return undefined;
@@ -151,7 +151,7 @@ export function changeLanguage(code: string): Thunk {
       code,
       label
     });
-    
+
     if (state.routing.locationBeforeTransitions.pathname === "/detail" && state.routing.locationBeforeTransitions.query.q) {
       dispatch(updateStudy(state.routing.locationBeforeTransitions.query.q.toString()));
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -211,7 +211,7 @@ export class Header extends Component<Props> {
             </div>
           </div>
         </div>
-		
+
          {showFilterSummary &&
           <div className="modal is-active">
             <div className="modal-background"/>
@@ -275,8 +275,8 @@ export class Header extends Component<Props> {
                               unsafe/>
               </section>
               <div className="modal-card-foot">
-                <Translate component="button" className="button is-light" 
-                              onClick={toggleAdvancedSearch} 
+                <Translate component="button" className="button is-light"
+                              onClick={toggleAdvancedSearch}
                               content="close"/>
               </div>
             </div>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -51,7 +51,7 @@ export default class Pagination extends AbstractItemList {
                href={'/?p=' + items[i].page}
                aria-label={counterpart.translate('pagination.page') + items[i].page}
                onClick={(e) => {
-                 e.preventDefault(); 
+                 e.preventDefault();
                  setItems([items[i].page]);
                 }}>
               {items[i].label}
@@ -68,7 +68,7 @@ export default class Pagination extends AbstractItemList {
            href={'/?p=' + items[0].page}
            aria-label={counterpart.translate('pagination.previous') + items[0].page}
            onClick={(e) => {
-             e.preventDefault(); 
+             e.preventDefault();
              setItems([items[0].page]);
             }}>
           <FaChevronLeft/>
@@ -80,7 +80,7 @@ export default class Pagination extends AbstractItemList {
            href={'/?p=' + items[items.length - 1].page}
            aria-label={counterpart.translate('pagination.next') + items[items.length - 1].page}
            onClick={(e) => {
-             e.preventDefault(); 
+             e.preventDefault();
              setItems([items[items.length - 1].page]);
             }}>
           <FaChevronRight/>

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -35,7 +35,7 @@ export class Panel extends SearchkitPanel {
   props: Props;
 
   static readonly defaultProps = {
-    ...SearchkitPanel.defaultProps, 
+    ...SearchkitPanel.defaultProps,
     expandMetadataPanels: false,
     toggleMetadataPanels
   };

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -126,7 +126,7 @@ export class Result extends Component<Props, ComponentState> {
                   q: item.id,
                   lang: item.langAvailableIn[i].toLowerCase()
                 }
-              }} 
+              }}
               onClick={()=> this.props.changeLanguage(item.langAvailableIn[i])}>
           {item.langAvailableIn[i]}
         </Link>
@@ -134,7 +134,7 @@ export class Result extends Component<Props, ComponentState> {
     }
 
     const creators = generateCreatorElements(item);
-	
+
     return (
       <div className="list_hit" data-qa="hit">
         <h4 className={bemBlocks.item().mix(bemBlocks.container('hith4'))} lang={currentLanguage}>
@@ -150,7 +150,7 @@ export class Result extends Component<Props, ComponentState> {
           {creators}
         </div>
         <div className={bemBlocks.item().mix(bemBlocks.container('desc'))} lang={currentLanguage}>
-          {this.state.abstractExpanded ? 
+          {this.state.abstractExpanded ?
             <span dangerouslySetInnerHTML={{__html: item.abstractHighlightLong || item.abstractLong}}/>
           :
             <span dangerouslySetInnerHTML={{__html: item.abstractHighlightShort || item.abstractShort}}/>

--- a/src/components/SearchBox.ts
+++ b/src/components/SearchBox.ts
@@ -25,7 +25,7 @@ export type Props = SearchBoxProps & DispatchAndState
 
 // Extend the Searchkit SearchBox component to limit maximum characters and provide redirection.
 export class SearchBox extends SearchkitSearchBox {
-  
+
   props: Props;
 
   constructor(props: Props) {
@@ -38,7 +38,7 @@ export class SearchBox extends SearchkitSearchBox {
   }
 
   static defaultProps = {
-    ...SearchkitSearchBox.defaultProps as typeof SearchkitSearchBox.defaultProps & { blurAction: "search"}, 
+    ...SearchkitSearchBox.defaultProps as typeof SearchkitSearchBox.defaultProps & { blurAction: "search"},
     pathname: '',
     push,
     replace,

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -218,7 +218,7 @@ export class SearchPage extends Component<Props> {
                     hitsPerPage={30}
                     customHighlight={{
                       fields: {
-                        titleStudy: { number_of_fragments: 0 }, 
+                        titleStudy: { number_of_fragments: 0 },
                         abstract: { number_of_fragments: 0 }
                       }
                     }}

--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -13,19 +13,19 @@
 
 import {CMMStudy} from '../../common/metadata';
 import type {Action} from '../actions';
-import { 
-  INIT_SEARCHKIT, 
-  RESET_SEARCH, 
-  SearchkitState, 
-  TOGGLE_ADVANCED_SEARCH, 
-  TOGGLE_LOADING, 
+import {
+  INIT_SEARCHKIT,
+  RESET_SEARCH,
+  SearchkitState,
+  TOGGLE_ADVANCED_SEARCH,
+  TOGGLE_LOADING,
   TOGGLE_METADATA_PANELS,
-  TOGGLE_MOBILE_FILTERS, 
-  TOGGLE_SUMMARY, 
-  UPDATE_DISPLAYED, 
-  UPDATE_QUERY, 
+  TOGGLE_MOBILE_FILTERS,
+  TOGGLE_SUMMARY,
+  UPDATE_DISPLAYED,
+  UPDATE_QUERY,
   UPDATE_STATE,
-  UPDATE_TOTAL_STUDIES 
+  UPDATE_TOTAL_STUDIES
 } from '../actions/search';
 
 

--- a/src/utilities/language.ts
+++ b/src/utilities/language.ts
@@ -20,7 +20,7 @@
   //   label  : The English label for this language.
   //   index  : The Elasticsearch index containing data for this language.
   // }
-export const languages: readonly Language[] = 
+export const languages: readonly Language[] =
   [{
     code: 'cs',
     label: 'Czech',

--- a/src/utilities/searchkit.ts
+++ b/src/utilities/searchkit.ts
@@ -14,7 +14,7 @@
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import {SearchkitManager} from 'searchkit';
 
-/** 
+/**
  * Query builder used to create the query going to Elasticsearch (for search page).
  */
 export function queryBuilder(query: string): QueryDslQueryContainer {
@@ -39,7 +39,7 @@ export function queryBuilder(query: string): QueryDslQueryContainer {
   };
 }
 
-/** 
+/**
  * Query used to retrieve a single record by its ID (for detail page).
  * @param id the document to retrieve.
  */
@@ -51,7 +51,7 @@ export function detailQuery(id: string): QueryDslQueryContainer {
   };
 }
 
-/** 
+/**
  * Query used to retrieve a single record by its pid (for detail page).
  */
 export function pidQuery(pid: string): QueryDslQueryContainer {
@@ -68,7 +68,7 @@ export function pidQuery(pid: string): QueryDslQueryContainer {
 
 /**
  * Match all query
- */ 
+ */
 export function matchAllQuery(): QueryDslQueryContainer {
   return {
     match_all: {}

--- a/tests/server/elasticsearch.ts
+++ b/tests/server/elasticsearch.ts
@@ -56,16 +56,16 @@ describe('elasticsearch utilities', () => {
     it('should return an array of similars', async () => {
       const es = new Elasticsearch("test");
       await expect(es.getSimilars(mockStudy.titleStudy, mockStudy.id, "cmmstudy_en"))
-        .resolves.toStrictEqual([{ 
-          id: mockStudy.id, 
+        .resolves.toStrictEqual([{
+          id: mockStudy.id,
           title: mockStudy.titleStudy
         }]);
-      
+
       // Expect the correct call to have beem made
       expect(es.client.search).toBeCalledWith({
         size: 5,
         index: "cmmstudy_en",
-        query: { 
+        query: {
           bool: {
             must: {
               match: {

--- a/tests/server/helper.ts
+++ b/tests/server/helper.ts
@@ -108,7 +108,7 @@ describe('helper utilities', () => {
       // Status code should be 200
       expect(response.statusCode).toBe(200);
       expect(mockedGetStudy).toBeCalledWith("test", "cmmstudy_en");
-      
+
       // Assert fields of renderData are as expected
       const renderData = response._getRenderData() as Metadata;
       expect(renderData).toEqual({
@@ -139,7 +139,7 @@ describe('helper utilities', () => {
       // Status code should be 200
       expect(response.statusCode).toBe(200);
       expect(mockedGetStudy).toBeCalledWith("test", "cmmstudy_en");
-      
+
       // Assert fields of renderData are as expected
       const renderData = response._getRenderData() as Metadata;
       expect(renderData).toEqual({

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -199,7 +199,7 @@ describe('Detail component', () => {
   });
 
   it('should handle a related publication with no holdings', () => {
-    const { enzymeWrapper } = setup({ 
+    const { enzymeWrapper } = setup({
       relatedPublications: [
         {
           title: "Related publications title",

--- a/tests/src/components/Header.tsx
+++ b/tests/src/components/Header.tsx
@@ -54,7 +54,7 @@ describe('Header component', () => {
   it('should navigate to home from logo', () => {
     const { enzymeWrapper } = setup();
     enzymeWrapper.find('.cessda-eric').simulate('click');
-    
+
   });
 
   it('should show hide button when mobile filters visible', () => {

--- a/tests/src/components/SearchBox.tsx
+++ b/tests/src/components/SearchBox.tsx
@@ -41,7 +41,7 @@ function setup(partialProps?: Partial<Props>, browser?: Browser) {
 
   // Mock detect-browser detect() to return custom browser type.
   (detect as jest.MockedFunction<typeof detect>).mockImplementation(() =>  ({
-    name: browser || "chrome", 
+    name: browser || "chrome",
     version: (browser === "ie") ? "11" : "90",
     os: null,
     type: "browser"

--- a/tests/src/components/Similars.tsx
+++ b/tests/src/components/Similars.tsx
@@ -34,7 +34,7 @@ function setup(partialProps?: Partial<Props>) {
     ],
     currentLanguage: "en",
     push: jest.fn(),
-    ...partialProps 
+    ...partialProps
   };
 
   // Manually initialise searchkit history.

--- a/tests/src/containers/DetailPage.tsx
+++ b/tests/src/containers/DetailPage.tsx
@@ -59,7 +59,7 @@ describe('DetailPage container', () => {
           locationBeforeTransitions: {
             query: {
               q: props.query
-            } 
+            }
           }
         },
         language: {
@@ -89,7 +89,7 @@ describe('DetailPage container', () => {
           locationBeforeTransitions: {
             query: {
               q: props.query
-            } 
+            }
           }
         },
         language: {

--- a/tests/src/reducers/search.ts
+++ b/tests/src/reducers/search.ts
@@ -138,7 +138,7 @@ describe('Search reducer', () => {
     });
 
     const emptyStudy = getStudyModel({});
-    
+
     expect(
       search(
         initialState,

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -64,6 +64,6 @@ const config: Configuration = {
       process: 'process/browser',
     })
   ]
-} 
+}
 
 export default config;


### PR DESCRIPTION
This makes the code easier to read and removes unnecessary dependencies that have known transitive dependency security issues.