### PR TITLE
#567: Update data model to include Data Kind and General Data Format, display them combined as Kind of Data on Display page

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -80,6 +80,8 @@ export interface CMMStudy {
   relatedPublications: RelatedPublication[];
   /** Funding */
   funding: Funding[];
+  /** Data Kind free text */
+  dataKindFreeTexts: DataKindFreeText[];
 }
 
 export interface Creator {
@@ -146,6 +148,11 @@ export interface Funding {
   agency?: string;
 }
 
+export interface DataKindFreeText {
+  dataKindFreeText?: string;
+  type?: string;
+}
+
 /**
  * Creates a model to store/display study metadata in the user interface.
  *
@@ -192,7 +199,8 @@ export function getStudyModel(source: Partial<CMMStudy> | undefined, highlight?:
     langAvailableIn: (source.langAvailableIn || []).map(i => i.toUpperCase()).sort(),
     universe: source.universe,
     relatedPublications: source.relatedPublications || [],
-    funding: source.funding || []
+    funding: source.funding || [],
+    dataKindFreeTexts: source.dataKindFreeTexts || []
   });
 }
 

--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -80,8 +80,10 @@ export interface CMMStudy {
   relatedPublications: RelatedPublication[];
   /** Funding */
   funding: Funding[];
-  /** Data Kind free text */
+  /** Data kind free text */
   dataKindFreeTexts: DataKindFreeText[];
+  /** General data format */
+  generalDataFormats: TermVocabAttributes[];
 }
 
 export interface Creator {
@@ -200,7 +202,8 @@ export function getStudyModel(source: Partial<CMMStudy> | undefined, highlight?:
     universe: source.universe,
     relatedPublications: source.relatedPublications || [],
     funding: source.funding || [],
-    dataKindFreeTexts: source.dataKindFreeTexts || []
+    dataKindFreeTexts: source.dataKindFreeTexts || [],
+    generalDataFormats: source.generalDataFormats || []
   });
 }
 

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -196,24 +196,24 @@ export default class Detail extends React.Component<Props, State> {
   }
 
   /**
-   * Transforms the given dataKindFreeTexts and generalDataFormats to an array with
-   * all free texts, types and formats combined into the same array with
-   * duplicates also removed and placing types first, formats second and free texts last.
+   * Formats the given dataKindFreeTexts and generalDataFormats into the same array
+   * with all free texts, types and formats combined while removing duplicates.
+   * Array contains types first, general data formats second and free texts last.
    *
-   * @param dataKindFreeTexts the data kind free texts and types to transform
-   * @param generalDataFormats the general data formats to transform
-   * @returns the transformed free texts, types and formats in one array
+   * @param dataKindFreeTexts the data kind free texts and types to format
+   * @param generalDataFormats the general data formats to format
+   * @returns the formatted data kind free texts, types and formats in one array
    */
-  transformDataKind(dataKindFreeTexts: DataKindFreeText[], generalDataFormats: TermVocabAttributes[]): string[] {
-    const types = new Set<string>();
-    const freeTexts = new Set<string>();
-    const formats = new Set<string>();
-    dataKindFreeTexts.forEach(({ dataKindFreeText, type }) => {
-      if (type) types.add(type);
-      if (dataKindFreeText) freeTexts.add(dataKindFreeText);
+  formatDataKind(dataKindFreeTexts: DataKindFreeText[], generalDataFormats: TermVocabAttributes[]): string[] {
+    const uniqueValues = new Set<string>();
+    dataKindFreeTexts.forEach(({ type }) => {
+      if (type) uniqueValues.add(type);
     });
-    generalDataFormats.forEach(item => formats.add(item.term));
-    return [...types, ...formats, ...freeTexts];
+    generalDataFormats.forEach(item => uniqueValues.add(item.term));
+    dataKindFreeTexts.forEach(({ dataKindFreeText }) => {
+      if (dataKindFreeText) uniqueValues.add(dataKindFreeText);
+    });
+    return Array.from(uniqueValues);
   }
 
   render() {
@@ -388,7 +388,7 @@ Summary information
             component="h3"
             content="metadata.dataKind"
           />
-          {item.dataKindFreeTexts || item.generalDataFormats ? this.generateElements(this.transformDataKind(item.dataKindFreeTexts, item.generalDataFormats), 'div', text =>
+          {item.dataKindFreeTexts || item.generalDataFormats ? this.generateElements(this.formatDataKind(item.dataKindFreeTexts, item.generalDataFormats), 'div', text =>
             <div className="data-abstract" dangerouslySetInnerHTML={{__html: text}}/>
           ) : <Translate content="language.notAvailable.field" lang={lang} /> }
 

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -18,7 +18,7 @@ import Tooltip from './Tooltip';
 import Panel from "./Panel";
 import Translate from "react-translate-component";
 import { upperFirst } from "lodash";
-import { CMMStudy, DataCollectionFreeText, DataKindFreeText, Universe } from "../../common/metadata";
+import { CMMStudy, DataCollectionFreeText, DataKindFreeText, TermVocabAttributes, Universe } from "../../common/metadata";
 import { ChronoField, DateTimeFormatter, DateTimeFormatterBuilder } from "@js-joda/core";
 import { FaAngleDown, FaAngleUp } from "react-icons/fa";
 import striptags from "striptags";
@@ -196,21 +196,24 @@ export default class Detail extends React.Component<Props, State> {
   }
 
   /**
-   * Transforms the given dataKindFreeTexts from DataKindFreeText[] to string[] with
-   * all free texts and types combined into the same array with types before free texts
-   * and duplicates removed.
+   * Transforms the given dataKindFreeTexts and generalDataFormats to an array with
+   * all free texts, types and formats combined into the same array with
+   * duplicates also removed and placing types first, formats second and free texts last.
    *
    * @param dataKindFreeTexts the data kind free texts and types to transform
-   * @returns the transformed data kind free texts and types in one array
+   * @param generalDataFormats the general data formats to transform
+   * @returns the transformed free texts, types and formats in one array
    */
-  transformDataKindFreeTexts(dataKindFreeTexts: DataKindFreeText[]): string[] {
+  transformDataKind(dataKindFreeTexts: DataKindFreeText[], generalDataFormats: TermVocabAttributes[]): string[] {
     const types = new Set<string>();
     const freeTexts = new Set<string>();
+    const formats = new Set<string>();
     dataKindFreeTexts.forEach(({ dataKindFreeText, type }) => {
       if (type) types.add(type);
       if (dataKindFreeText) freeTexts.add(dataKindFreeText);
     });
-    return [...types, ...freeTexts];
+    generalDataFormats.forEach(item => formats.add(item.term));
+    return [...types, ...formats, ...freeTexts];
   }
 
   render() {
@@ -385,7 +388,7 @@ Summary information
             component="h3"
             content="metadata.dataKind"
           />
-          {item.dataKindFreeTexts ? this.generateElements(this.transformDataKindFreeTexts(item.dataKindFreeTexts), 'div', text =>
+          {item.dataKindFreeTexts || item.generalDataFormats ? this.generateElements(this.transformDataKind(item.dataKindFreeTexts, item.generalDataFormats), 'div', text =>
             <div className="data-abstract" dangerouslySetInnerHTML={{__html: text}}/>
           ) : <Translate content="language.notAvailable.field" lang={lang} /> }
 

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -18,7 +18,7 @@ import Tooltip from './Tooltip';
 import Panel from "./Panel";
 import Translate from "react-translate-component";
 import { upperFirst } from "lodash";
-import { CMMStudy, DataCollectionFreeText, Universe } from "../../common/metadata";
+import { CMMStudy, DataCollectionFreeText, DataKindFreeText, Universe } from "../../common/metadata";
 import { ChronoField, DateTimeFormatter, DateTimeFormatterBuilder } from "@js-joda/core";
 import { FaAngleDown, FaAngleUp } from "react-icons/fa";
 import striptags from "striptags";
@@ -195,6 +195,24 @@ export default class Detail extends React.Component<Props, State> {
     }
   }
 
+  /**
+   * Transforms the given dataKindFreeTexts from DataKindFreeText[] to string[] with
+   * all free texts and types combined into the same array with types before free texts
+   * and duplicates removed.
+   *
+   * @param dataKindFreeTexts the data kind free texts and types to transform
+   * @returns the transformed data kind free texts and types in one array
+   */
+  transformDataKindFreeTexts(dataKindFreeTexts: DataKindFreeText[]): string[] {
+    const types = new Set<string>();
+    const freeTexts = new Set<string>();
+    dataKindFreeTexts.forEach(({ dataKindFreeText, type }) => {
+      if (type) types.add(type);
+      if (dataKindFreeText) freeTexts.add(dataKindFreeText);
+    });
+    return [...types, ...freeTexts];
+  }
+
   render() {
     const { item, lang } = this.props;
 
@@ -361,6 +379,15 @@ Summary information
           {this.generateElements(item.samplingProcedureFreeTexts, 'div', text =>
             <div className="data-abstract" dangerouslySetInnerHTML={{__html: text}}/>
           )}
+
+          <Translate
+            className="data-label"
+            component="h3"
+            content="metadata.dataKind"
+          />
+          {item.dataKindFreeTexts ? this.generateElements(this.transformDataKindFreeTexts(item.dataKindFreeTexts), 'div', text =>
+            <div className="data-abstract" dangerouslySetInnerHTML={{__html: text}}/>
+          ) : <Translate content="language.notAvailable.field" lang={lang} /> }
 
           <Translate
             className="data-label"

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -46,6 +46,11 @@ describe('Metadata utilities', () => {
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',
           dataCollectionPeriodStartdate: '2001',
+          dataKindFreeTexts: [
+            { dataKindFreeText: "Numeric", type: "Quantitative" },
+            { dataKindFreeText: "Text", type: "Quantitative" },
+            { dataKindFreeText: "Other" },
+          ],
           fileLanguages: ['en'],
           funding: [
             {
@@ -143,6 +148,11 @@ describe('Metadata utilities', () => {
         dataCollectionPeriodEnddate: '',
         dataCollectionPeriodStartdate: '2001',
         dataCollectionYear: undefined,
+        dataKindFreeTexts: [
+          { dataKindFreeText: "Numeric", type: "Quantitative" },
+          { dataKindFreeText: "Text", type: "Quantitative" },
+          { dataKindFreeText: "Other" },
+        ],
         fileLanguages: ['en'],
         funding: [
           {
@@ -235,6 +245,7 @@ describe('Metadata utilities', () => {
         dataCollectionPeriodEnddate: '',
         dataCollectionPeriodStartdate: '',
         dataCollectionYear: undefined,
+        dataKindFreeTexts: [],
         fileLanguages: [],
         funding: [],
         keywords: [],
@@ -298,6 +309,7 @@ describe('Metadata utilities', () => {
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',
           dataCollectionPeriodStartdate: '2001',
+          dataKindFreeTexts: [],
           fileLanguages: ['en'],
           funding: [],
           keywords: [
@@ -438,6 +450,7 @@ describe('Metadata utilities', () => {
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',
           dataCollectionPeriodStartdate: '2001',
+          dataKindFreeTexts: [],
           fileLanguages: ['en'],
           funding: [],
           keywords: [],

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -58,6 +58,14 @@ describe('Metadata utilities', () => {
               agency: 'Some Agency'
             }
           ],
+          generalDataFormats: [
+            {
+              id: '',
+              term: 'Numeric',
+              vocab: 'GeneralDataFormat',
+              vocabUri: 'urn:ddi:int.ddi.cv:GeneralDataFormat:2.0.3'
+            }
+          ],
           keywords: [
             {
               id: 'UKDS1234',
@@ -160,6 +168,14 @@ describe('Metadata utilities', () => {
             agency: 'Some Agency'
           }
         ],
+        generalDataFormats: [
+          {
+            id: '',
+            term: 'Numeric',
+            vocab: 'GeneralDataFormat',
+            vocabUri: 'urn:ddi:int.ddi.cv:GeneralDataFormat:2.0.3'
+          }
+        ],
         keywords: [
           {
             id: 'UKDS1234',
@@ -248,6 +264,7 @@ describe('Metadata utilities', () => {
         dataKindFreeTexts: [],
         fileLanguages: [],
         funding: [],
+        generalDataFormats: [],
         keywords: [],
         langAvailableIn: [],
         lastModified: '',
@@ -312,6 +329,7 @@ describe('Metadata utilities', () => {
           dataKindFreeTexts: [],
           fileLanguages: ['en'],
           funding: [],
+          generalDataFormats: [],
           keywords: [
             {
               id: 'UKDS1234',
@@ -453,6 +471,7 @@ describe('Metadata utilities', () => {
           dataKindFreeTexts: [],
           fileLanguages: ['en'],
           funding: [],
+          generalDataFormats: [],
           keywords: [],
           langAvailableIn: ['EN'],
           lastModified: '2001-01-01T12:00:00Z',

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -49,6 +49,14 @@ export const mockStudy: CMMStudy = {
       agency: 'Some Agency'
     }
   ],
+  generalDataFormats: [
+    {
+      id: '',
+      term: 'Numeric',
+      vocab: 'GeneralDataFormat',
+      vocabUri: 'urn:ddi:int.ddi.cv:GeneralDataFormat:2.0.3'
+    }
+  ],
   keywords: [
     {
       id: '',

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -38,9 +38,10 @@ export const mockStudy: CMMStudy = {
   dataCollectionPeriodStartdate: '2001',
   dataCollectionYear: 2001,
   dataKindFreeTexts: [
-    { dataKindFreeText: "Text" },
-    { dataKindFreeText: "Software" },
+    { dataKindFreeText: "Software", },
+    { dataKindFreeText: "Text", type: "Quantitative" },
     { dataKindFreeText: "Other" },
+    { type: "Numeric" }
   ],
   fileLanguages: ['en'],
   funding: [

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -37,6 +37,11 @@ export const mockStudy: CMMStudy = {
   dataCollectionPeriodEnddate: '',
   dataCollectionPeriodStartdate: '2001',
   dataCollectionYear: 2001,
+  dataKindFreeTexts: [
+    { dataKindFreeText: "Text" },
+    { dataKindFreeText: "Software" },
+    { dataKindFreeText: "Other" },
+  ],
   fileLanguages: ['en'],
   funding: [
     {

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -248,4 +248,20 @@ describe('Detail component', () => {
     const fundingPanel = enzymeWrapper.find('#funding-information');
     expect(fundingPanel.exists()).toBe(false);
   })
+
+  it('should transform data kind free texts', () => {
+    const { detailInstance } = setup();
+    const input = [
+      { dataKindFreeText: "Numeric", },
+      { dataKindFreeText: "Text", type: "Quantitative" },
+      { dataKindFreeText: "Other" },
+    ];
+    const expectedOutput = [
+      "Quantitative",
+      "Numeric",
+      "Text",
+      "Other"
+    ];
+    expect(detailInstance.transformDataKindFreeTexts(input)).toEqual(expectedOutput);
+  });
 });

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -249,21 +249,8 @@ describe('Detail component', () => {
     expect(fundingPanel.exists()).toBe(false);
   })
 
-  it('should transform data kind free texts', () => {
+  it('should format data kind values from free texts, types and general data formats into one array', () => {
     const { detailInstance } = setup();
-    const dataKindFreeTexts = [
-      { dataKindFreeText: "Software", },
-      { dataKindFreeText: "Text", type: "Quantitative" },
-      { dataKindFreeText: "Other" },
-    ];
-    const generalDataFormats = [
-      {
-        id: '',
-        term: 'Numeric',
-        vocab: 'GeneralDataFormat',
-        vocabUri: 'urn:ddi:int.ddi.cv:GeneralDataFormat:2.0.3'
-      }
-    ]
     const expectedOutput = [
       "Quantitative",
       "Numeric",
@@ -271,6 +258,6 @@ describe('Detail component', () => {
       "Text",
       "Other"
     ];
-    expect(detailInstance.transformDataKind(dataKindFreeTexts, generalDataFormats)).toEqual(expectedOutput);
+    expect(detailInstance.formatDataKind(mockStudy.dataKindFreeTexts, mockStudy.generalDataFormats)).toEqual(expectedOutput);
   });
 });

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -251,17 +251,26 @@ describe('Detail component', () => {
 
   it('should transform data kind free texts', () => {
     const { detailInstance } = setup();
-    const input = [
-      { dataKindFreeText: "Numeric", },
+    const dataKindFreeTexts = [
+      { dataKindFreeText: "Software", },
       { dataKindFreeText: "Text", type: "Quantitative" },
       { dataKindFreeText: "Other" },
     ];
+    const generalDataFormats = [
+      {
+        id: '',
+        term: 'Numeric',
+        vocab: 'GeneralDataFormat',
+        vocabUri: 'urn:ddi:int.ddi.cv:GeneralDataFormat:2.0.3'
+      }
+    ]
     const expectedOutput = [
       "Quantitative",
       "Numeric",
+      "Software",
       "Text",
       "Other"
     ];
-    expect(detailInstance.transformDataKindFreeTexts(input)).toEqual(expectedOutput);
+    expect(detailInstance.transformDataKind(dataKindFreeTexts, generalDataFormats)).toEqual(expectedOutput);
   });
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -203,7 +203,8 @@
     "relatedPublications": "Related publications",
     "funding": "Funding information",
     "funder": "Funder",
-    "grantNumber": "Grant Number"
+    "grantNumber": "Grant number",
+    "dataKind": "Kind of data"
   },
   "header": {
     "frontPage": "Front/search page",


### PR DESCRIPTION
Requires indexing with [https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/122](https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/122) to work.

SPs using Data Kind in DDI-C 2.5 mostly use values that basically the same as in [DDI-L 3.3 General Data Format CV](https://vocabularies.cessda.eu/vocabulary/GeneralDataFormat)  so I think it makes sense to combine them under Kind of Data. [DDI-C 2.5 dataKind element](https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/dataKind.html) has an example ```<dataKind type="numeric">survey data</dataKind>``` so I'm not sure where the values Quantitative, Qualitative and Mixed that FSD are using should be but we have them as the text value while in [DDI-L 3.3 KindOfData](https://ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/FieldLevelDocumentation/schemas/reusable_xsd/elements/KindOfData.html) they would be in attribute type. Doesn't matter much for this implementation since it will just list all the values whether they are in element type attribute or element text.