### PR TITLE
#677: Add ORCID iD icon before ORCID iD URL

### DIFF
--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -25,6 +25,7 @@ import striptags from "striptags";
 import counterpart from "counterpart";
 import Keywords from "./Keywords";
 import SeriesList from './SeriesList';
+import OrcidLogo from "./OrcidLogo";
 
 export interface Props {
   item: CMMStudy;
@@ -213,16 +214,24 @@ export default class Detail extends React.Component<Props, State> {
         {creator.identifier && (
           <>
             {" - "}
-            {creator.identifier.type ? creator.identifier.type : "Research Identifier"}
-            {": "}
-            {creator.identifier.uri ? (
-              <a href={creator.identifier.uri} target="_blank" rel="noreferrer">
-                <span className="icon"><FaExternalLinkAlt /></span>
-                {creator.identifier.id ? creator.identifier.id : creator.identifier.uri}
-              </a>
-            ) : (
-              creator.identifier.id
-            )}
+            <span className="is-inline-block">
+              {creator.identifier.type?.toLowerCase() !== "orcid" &&
+                <>
+                  {creator.identifier.type || "Research Identifier"}{": "}
+                </>
+              }
+              {creator.identifier.uri ? (
+                <a href={creator.identifier.uri} target="_blank" rel="noreferrer">
+                  {creator.identifier.type?.toLowerCase() === "orcid" &&
+                    <OrcidLogo />
+                  }
+                  <span className="icon"><FaExternalLinkAlt /></span>
+                  {creator.identifier.id ? creator.identifier.id : creator.identifier.uri}
+                </a>
+              ) : (
+                creator.identifier.id
+              )}
+            </span>
           </>
         )}
       </span>

--- a/src/components/OrcidLogo.tsx
+++ b/src/components/OrcidLogo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default ({ width = 24, height = 24, fillColor = "#000000", className = 'orcid-logo mr-5' }) => {
+  return (
+    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+      viewBox="0 0 256 256" width={width} height={height} className={className} aria-label="ORCID logo">
+      <path fill={fillColor} d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z" />
+      <g>
+        <path fill={"#FFFFFF"} d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z" />
+        <path fill={"#FFFFFF"} d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+        <path fill={"#FFFFFF"} d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+      </g>
+    </svg>
+  );
+};

--- a/src/styles/modules/_body.scss
+++ b/src/styles/modules/_body.scss
@@ -452,6 +452,11 @@ padding: 6px 0;
   margin-bottom: 5px;
 }
 
+.orcid-logo {
+  transform: translateY(-2px);
+  vertical-align: middle;
+}
+
 select::-ms-expand {
   display: none;
 }

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -265,11 +265,10 @@ describe('Detail component', () => {
     const { detailInstance } = setup();
 
     mockStudy.creators.forEach((creator) => {
-      const formattedCreator = shallow(detailInstance.formatCreator(creator));
+      const formattedCreator = mount(detailInstance.formatCreator(creator));
       const expectedAffiliation = creator.affiliation ? ` (${creator.affiliation})` : '';
-      // Also includes expected punctuation marks before and after identifier type / default text
       const expectedIdentifierType = creator.identifier
-        ? ` - ${creator.identifier.type || "Research Identifier"}: `
+        ? (creator.identifier.type?.toLowerCase() === "orcid" ? null : `${creator.identifier.type || "Research Identifier"}: `)
         : '';
       const expectedIdentifier = creator.identifier?.id;
       const expectedLinkText = creator.identifier?.id || creator.identifier?.uri;
@@ -277,12 +276,17 @@ describe('Detail component', () => {
 
       expect(formattedCreator.text()).toContain(creator.name);
       if (expectedAffiliation) expect(formattedCreator.text()).toContain(expectedAffiliation);
-      if (expectedIdentifierType) expect(formattedCreator.text()).toContain(expectedIdentifierType);
+      // Check for identifier type or ORCID logo
+      if (expectedIdentifierType) {
+        expect(formattedCreator.text()).toContain(expectedIdentifierType);
+      } else if (creator.identifier?.type?.toLowerCase() === "orcid") {
+        expect(formattedCreator.html()).toContain('ORCID logo');
+      }
       if (expectedIdentifier) expect(formattedCreator.text()).toContain(expectedIdentifier);
       if (expectedLinkHref) {
         expect(formattedCreator.find('a').prop('href')).toEqual(expectedLinkHref);
         expect(formattedCreator.find('a').text()).toContain(expectedLinkText);
       }
     });
-  })
+  });
 });


### PR DESCRIPTION
Not perfectly happy about having to use `transform: translateY(-2px);` to vertically align the logo (`vertical-align: middle;` alone is not perfect). It could be done with `align-items: center;` with flexbox but I tried it and it just becomes too much of a mess to then get everything else perfect.

I replaced "ORCID: " with this ORCID logo since it basically conveys the same information.