### PR TITLE
Enable Norwegian language support

### DIFF
--- a/src/utilities/language.ts
+++ b/src/utilities/language.ts
@@ -54,6 +54,10 @@ export const languages: readonly Language[] =
     label: 'Greek',
     index: 'cmmstudy_el'
   }, {
+    code: 'no',
+    label: 'Norwegian',
+    index: 'cmmstudy_no'
+  }, {
     code: 'sk',
     label: 'Slovakian',
     index: 'cmmstudy_sk'


### PR DESCRIPTION
Now that Sikt is being harvested, Norwegian language support can be enabled.