### PR TITLE
Remove Danish language support

### DIFF
--- a/src/utilities/language.ts
+++ b/src/utilities/language.ts
@@ -26,10 +26,6 @@ export const languages: readonly Language[] =
     label: 'Czech',
     index: 'cmmstudy_cs'
   },{
-    code: 'da',
-    label: 'Danish',
-    index: 'cmmstudy_da'
-  },{
     code: 'nl',
     label: 'Dutch',
     index: 'cmmstudy_nl'


### PR DESCRIPTION
DNA has been removed from the CDC, so Danish language support can be removed