### PR TITLE
#685: Fix searching from creators and keywords, rename fields with normalizer from raw to normalized

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -303,12 +303,12 @@ function externalApiV2() {
         break;
       case "titleAscending":
         sort = {
-          'titleStudy.raw': 'asc'
+          'titleStudy.normalized': 'asc'
         };
         break;
       case "titleDescending":
         sort = {
-          'titleStudy.raw': 'desc'
+          'titleStudy.normalized': 'desc'
         };
         break;
       case "dateOfCollectionOldest":
@@ -372,7 +372,7 @@ function externalApiV2() {
         }
       });
     } else if (_.isString(q)) {
-      //create json body for ElasticSearchClient - search query
+      // Create json body for ElasticSearchClient - search query
       mustQuery.push({
         simple_query_string: {
           query: q,
@@ -381,8 +381,8 @@ function externalApiV2() {
           fields: [
             "titleStudy^4",
             "abstract^2",
-            "creators.name^2",
-            "keywords.term^1.5",
+            "creatorsSearchField^2",
+            "keywordsSearchField^1.5",
             "*"
           ],
           flags: "AND|OR|NOT|PHRASE|PRECEDENCE|PREFIX"

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -40,13 +40,13 @@ export default () => (
             }, {
               label: counterpart.translate('sorting.titleAscending'),
               key: 'title-ascending',
-              field: 'titleStudy.raw',
+              field: 'titleStudy.normalized',
               order: 'asc',
               defaultOption: false
             }, {
               label: counterpart.translate('sorting.titleDescending'),
               key: 'title-descending',
-              field: 'titleStudy.raw',
+              field: 'titleStudy.normalized',
               order: 'desc',
               defaultOption: false
             }, {

--- a/src/containers/SearchPage.tsx
+++ b/src/containers/SearchPage.tsx
@@ -94,7 +94,7 @@ export class SearchPage extends Component<Props> {
               <div className="float">
                 <RefinementListFilter id="classifications.term"
                                       title={counterpart.translate('filters.topic.label')}
-                                      field={'classifications.term.raw'}
+                                      field={'classifications.term.normalized'}
                                       fieldOptions={{
                                         type: 'nested',
                                         options: {path: 'classifications', min_doc_count: 1}
@@ -118,7 +118,7 @@ export class SearchPage extends Component<Props> {
 
                 <RefinementListFilter id="keywords.term"
                                       title={counterpart.translate('filters.keywords.label')}
-                                      field={'keywords.term.raw'}
+                                      field={'keywords.term.normalized'}
                                       fieldOptions={{
                                         type: 'nested',
                                         options: {path: 'keywords', min_doc_count: 1}

--- a/tests/src/components/SortingSelector.tsx
+++ b/tests/src/components/SortingSelector.tsx
@@ -33,14 +33,14 @@ function setup() {
         translation: 'sorting.titleAscending',
         label: '',
         key: 'title-ascending',
-        field: 'titleStudy.raw',
+        field: 'titleStudy.normalized',
         order: 'asc'
       },
       {
         translation: 'sorting.titleDescending',
         label: '',
         key: 'title-descending',
-        field: 'titleStudy.raw',
+        field: 'titleStudy.normalized',
         order: 'desc'
       },
       {


### PR DESCRIPTION
Requires mappings changes to indices from https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/157.

Could have been fixed by changing the search query in <code>helper.ts</code> to search from nested paths but I feel like it's better and simpler by adding search fields in mappings that can be used instead.