### PR TITLE
#720: Adjust tooltip position, extend tooltip area with padding, fix tooltip blur issues

### DIFF
--- a/src/styles/modules/_tooltip.scss
+++ b/src/styles/modules/_tooltip.scss
@@ -18,13 +18,25 @@
     }
   }
 
-  .dropdown-menu {
+  .tooltip-content {
     min-width: 14rem;
+    pointer-events: auto;
+  }
+
+  .tooltip-icon {
+    pointer-events: all;
+  }
+
+  .tooltip-below {
+    top: calc(100% - 28px);
+    bottom: unset;
+    padding-top: 16px;
   }
 
   .tooltip-above {
-    bottom: 100%;
+    bottom: calc(100% - 28px);
     top: unset;
+    padding-bottom: 16px;
   }
 
   .dropdown-content .dropdown-item a {

--- a/tests/src/components/Tooltip.tsx
+++ b/tests/src/components/Tooltip.tsx
@@ -30,8 +30,8 @@ it('should render', () => {
 
 it('should display content on hover', async () => {
   render(<Tooltip {...baseProps} />);
-  const tooltipContainer = screen.getByTestId('tooltip-container');
-  userEvent.hover(tooltipContainer);
+  const tooltipIcon = screen.getByTestId('tooltip-icon');
+  userEvent.hover(tooltipIcon);
 
   // Wait for the tooltip content to appear
   await waitFor(() => {
@@ -44,16 +44,15 @@ it('should display content on hover', async () => {
 it('should hide content on mouse leave', async () => {
   render(<Tooltip {...baseProps} />);
   
-  const tooltipButton = screen.getByTestId('tooltip-button');
-  userEvent.hover(tooltipButton);
+  const tooltipIcon = screen.getByTestId('tooltip-icon');
+  userEvent.hover(tooltipIcon);
   
   // Wait for the tooltip content to appear
   await waitFor(() => {
     expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
   });
 
-  const tooltipContainer = screen.getByTestId('tooltip-container');
-  userEvent.unhover(tooltipContainer);
+  userEvent.unhover(tooltipIcon);
   
   // Wait for tooltip content to disappear
   await waitFor(() => {
@@ -109,7 +108,13 @@ it('should hide content on Escape key press', async () => {
 });
 
 it('should hide content on blur', async () => {
-  render(<Tooltip {...baseProps} />);
+  render(
+    <>
+      <Tooltip {...baseProps} />
+      <button data-testid="after-tooltip">Next</button>
+    </>
+  );
+
   const tooltipButton = screen.getByTestId('tooltip-button');
 
   // Ensure the tooltip button is focused
@@ -123,12 +128,15 @@ it('should hide content on blur', async () => {
     expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
   });
 
-  // Simulate blur event (by focusing on another element)
+  // First tab: focus moves to tooltip content
+  userEvent.tab();
+
+  // Second tab: focus moves to the next button, triggering blur
   userEvent.tab();
 
   // Wait for the tooltip content to disappear
   await waitFor(() => {
-    expect(screen.queryByTestId('tooltip-content')).toBeNull();
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
This fixes https://github.com/cessda/cessda.cdc.versions/issues/720 and also an issue with keyboard navigation
- Adjusted tooltip content position to not have empty space between content and tooltip button
- Added padding to tooltip content that covers the button and area next to it so tooltip won't close while moving from button to content
- Allow focusing links in tooltip content with tab without closing tooltip