### PR TITLE
#721: Fix selected data access filter options missing from query params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,9 +108,10 @@ const Root = () => {
           query: indexUiState.query,
           classifications: indexUiState.refinementList?.classifications,
           keywords: indexUiState.refinementList?.keywords,
-          publisher: indexUiState.refinementList?.publisher,
+          dataAccess: indexUiState.refinementList?.dataAccess,
           collectionYear: indexUiState.range?.collectionYear,
           country: indexUiState.refinementList?.country,
+          publisher: indexUiState.refinementList?.publisher,
           timeMethod: indexUiState.refinementList?.timeMethod,
           timeMethodCV: indexUiState.refinementList?.timeMethodCV,
           resultsPerPage: indexUiState.hitsPerPage,
@@ -129,8 +130,9 @@ const Root = () => {
             refinementList: {
               classifications: routeState.classifications || [],
               keywords: routeState.keywords || [],
-              publisher: routeState.publisher || [],
+              dataAccess: routeState.dataAccess || [],
               country: routeState.country || [],
+              publisher: routeState.publisher || [],
               timeMethod: routeState.timeMethod || [],
               timeMethodCV: routeState.timeMethodCV || []
             },


### PR DESCRIPTION
Fixes https://github.com/cessda/cessda.cdc.versions/issues/721. It wasn't related to the recently created <code>CustomRefinementList</code>. Instead I've just forgot to add it to stateMapping in routing when first adding data access support and it has gone unnoticed since then.