### PR TITLE
#660: Sort related publications by publication date, check that publication link starts with http

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -116,6 +116,7 @@ export interface DataCollectionFreeText {
 export interface RelatedPublication {
   title: string;
   holdings: string[];
+  publicationDate: string;
   lang?: string;
 }
 

--- a/server/elasticsearch.ts
+++ b/server/elasticsearch.ts
@@ -109,6 +109,7 @@ export default class Elasticsearch {
         return (hit._source?.relatedPublications || []).map(publication => ({
             title: publication.title,
             holdings: publication.holdings,
+            publicationDate: publication.publicationDate,
             // Add lang according to the language part of index name
             lang: hit._index.split('_')[1]
         }));

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -737,31 +737,36 @@ const Detail = (props: Props) => {
             </section>
 
             <section className="metadata-section">
-
               {!currentThematicView.excludeFields.includes('relatedPublications') &&
                 <>
                   {generateHeading('relPub')}
                   {generateElements(
-                    item.relatedPublications,
+                    // Sort related publications by publication date, descending
+                    [...item.relatedPublications]
+                      .sort((a, b) => {
+                        const parseDate = (d: string) => d ? new Date(d) : null;
+                        const dateA = parseDate(a.publicationDate);
+                        const dateB = parseDate(b.publicationDate);
+
+                        if (!dateA && !dateB) return 0;
+                        if (!dateA) return 1;
+                        if (!dateB) return -1;
+                        return dateB.getTime() - dateA.getTime();
+                      }),
                     "ul",
                     (relatedPublication) => {
-                      const relatedPublicationTitle = striptags(
-                        relatedPublication.title
+                      const relatedPublicationTitle = striptags(relatedPublication.title);
+                      const holdingUrl = relatedPublication.holdings?.find(h => h.startsWith('http'));
+
+                      return holdingUrl ? (
+                        <a href={holdingUrl}>{relatedPublicationTitle}</a>
+                      ) : (
+                        relatedPublicationTitle
                       );
-                      if (relatedPublication.holdings?.length > 0) {
-                        return (
-                          <a href={relatedPublication.holdings[0]}>
-                            {relatedPublicationTitle}
-                          </a>
-                        );
-                      } else {
-                        return relatedPublicationTitle;
-                      }
                     }
                   )}
                 </>
               }
-
             </section>
 
 

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -744,9 +744,8 @@ const Detail = (props: Props) => {
                     // Sort related publications by publication date, descending
                     [...item.relatedPublications]
                       .sort((a, b) => {
-                        const parseDate = (d: string) => d ? new Date(d) : null;
-                        const dateA = parseDate(a.publicationDate);
-                        const dateB = parseDate(b.publicationDate);
+                        const dateA = a.publicationDate ? new Date(a.publicationDate) : undefined;
+                        const dateB = b.publicationDate ? new Date(b.publicationDate) : undefined;
 
                         if (!dateA && !dateB) return 0;
                         if (!dateA) return 1;

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -87,7 +87,8 @@ export const mockStudy: CMMStudy = {
       title: "Related Publication 1",
       holdings: [
         "First Holding"
-      ]
+      ],
+      publicationDate: "2001"
     }
   ],
   samplingProcedureFreeTexts: [

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -33,7 +33,8 @@ const baseProps: Props = {
     { collPeriod: { id: 'data-collection-period', level: 'subtitle', translation: ("Data collection period") } },
     { country: { id: 'country', level: 'subtitle', translation: ("Country") } },
     { universe: { id: 'universe', level: 'subtitle', translation: ("Universe") } },
-    { publicationYear: { id: 'publication-year', level: 'subtitle', translation: ("Publication year") } }
+    { publicationYear: { id: 'publication-year', level: 'subtitle', translation: ("Publication year") } },
+    { relPub: { id: 'related-publications', level: 'subtitle', translation: ("Related publications") } }
   ]
 };
 
@@ -152,16 +153,34 @@ it("should handle formatting dates as a range with valid second date but undefin
   checkValueAfterHeading('Data collection period', 'language.notAvailable.field');
 });
 
-it("should handle formatting dates as a range with invalid first date", () => {
+it("should render related publications sorted by publication date", () => {
   renderDetailWithModifiedProps({
     relatedPublications: [
       {
-        title: "Related publications title",
+        title: "Oldest related publication",
         holdings: [],
+        publicationDate: "2015"
+      },
+      {
+        title: "Newest related publication",
+        holdings: [],
+        publicationDate: "2023"
+      },
+      {
+        title: "Undated related publication",
+        holdings: [],
+        publicationDate: ""
       }
     ]
   });
-  expect(screen.getByRole('article')).toBeInTheDocument();
+
+  const newest = screen.getByText("Newest related publication");
+  const oldest = screen.getByText("Oldest related publication");
+  const undated = screen.getByText("Undated related publication");
+
+  // Assert order: newest -> oldest -> undated
+  expect(newest.compareDocumentPosition(oldest) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(oldest.compareDocumentPosition(undated) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
 it("should handle no universe exclusion provided", () => {


### PR DESCRIPTION
Added sort for related publications and also link for related publications is now the first one that starts with <code>http</code> instead of just the first holdings value since not all URIs are URLs.

Requires building indices again with https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/189 to work.