### PR TITLE
Use DOM APIs to sanitise <a> tags, escape all special regex characters when highlighting

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -250,16 +250,52 @@ function stripHTMLElements(html: string) {
     "h5",
     "h6",
   ]);
-  function sanitizeAnchorTags(html: string): string {
-    return html.replace(/<a\s+([^>]*href="[^"]+"[^>]*)>/gi, (_match, attrs) => {
-      // Extract href
-      const hrefMatch = attrs.match(/href="[^"]+"/i);
-      const href = hrefMatch ? hrefMatch[0] : '';
 
-      return `<a ${href} target="_blank" rel="noopener noreferrer">`;
-    });
-  }
   return sanitizeAnchorTags(strippedHTML.trim());
+}
+
+/**
+ * Sanitize &lt;a&gt; tags by setting target="_blank" and rel="noopener noreferrer".
+ * All other attributes are removed.
+ * 
+ * @param html the HTML to sanitize.
+ * @returns the sanitized HTML.
+ */
+function sanitizeAnchorTags(html: string): string {
+  const parser = new DOMParser();
+  const parsedHTML = parser.parseFromString(html, "text/html");
+  
+  // Get all <a> elements
+  const anchorElements = parsedHTML.getElementsByTagName("a");
+
+  for(const elem of anchorElements) {
+    // Store the href
+    const href = elem.href;
+
+    // Clear other attributes
+    for (const attr of elem.getAttributeNames()) {
+      elem.removeAttribute(attr);
+    }
+
+    // Copy href
+    elem.href = href;
+
+    // Set target and rel attributes
+    elem.target = "_blank";
+    elem.rel = "noopener noreferrer";
+  }
+
+  return parsedHTML.body.innerHTML;
+}
+
+export function normalizeAndDecodeHTML(html: string) {
+  if (html) {
+    // Convert escaped HTML tags
+    html = html.replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+  }
+
+  // Strip non-styling elements from the HTML
+  return stripHTMLElements(html);
 }
 
 // Generates study JSON-LD for Google indexing.
@@ -367,6 +403,7 @@ function extractDataCollectionPeriod(
   return startDate + dataCollectionPeriodEnddate.substring(0, 10);
 }
 
+// TODO: implement with DOM
 export function getDDI(metadata: CMMStudy, lang: string): string {
   const {
     titleStudy, creators, dataCollectionPeriodStartdate, dataCollectionPeriodEnddate, dataCollectionYear,

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -132,7 +132,7 @@ describe('Metadata utilities', () => {
         id: '1',
         titleStudy: 'Study Title',
         titleStudyHighlight: '',
-        abstract: 'Abstract with link (<a href="http://example.com" target="_blank" rel="noopener noreferrer">Link text</a>)',
+        abstract: 'Abstract with link (<a href="http://example.com/" target="_blank" rel="noopener noreferrer">Link text</a>)',
         abstractShort: 'Abstract with link (Link text)',
         abstractLong: 'Abstract with link (Link text)',
         abstractHighlight: '',

--- a/tests/src/components/Result.tsx
+++ b/tests/src/components/Result.tsx
@@ -24,7 +24,7 @@ const baseMockHit = {
   objectID: "1",
   titleStudy: 'Full Study Title',
   _index: "coordinate_en",
-  abstract: "Long Abstract.\nAipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed augue lacus.",
+  abstract: "<P>Long Abstract.\nAipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed augue lacus. sneaky html</P>",
   creators: [
     { name: 'Jane Doe' },
     { name: 'University of Essex' },
@@ -109,7 +109,7 @@ it('renders result with title, creators, and abstract', () => {
   expect(screen.getByText('John Smith (University of Essex)')).toBeInTheDocument();
 
   // Abstract
-  expect(screen.getByText('Long Abstract. Aipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed augue...')).toBeInTheDocument();
+  expect(screen.getByText('Long Abstract. Aipiscing elit ut aliquam purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis leo vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus in ornare quam viverra orci sagittis eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices in iaculis nunc sed...')).toBeInTheDocument();
 });
 
 it('renders highlighted title', () => {


### PR DESCRIPTION
This PR replaces the `sanitizeAnchorTags()` function with a DOM equivalent. This will catch all instances of `<a>` tags.

The regex that matches highlight words does not handle regex special characters. This PR adds the ability for such characters to be escaped before attempting to construct the regex.

See https://github.com/cessda/cessda.cdc.searchkit/security/code-scanning/5