### PR TITLE
#733: Fix links from ELSST not working

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -836,6 +836,10 @@ function rewriteKeywordsQueryHandler(req: express.Request, res: express.Response
     // Add new keywords query, converting the keyword to lowercase
     query["keywords[]"] = (term as string).toLowerCase();
 
+    // Add sortBy that uses main CDC collection and delete lang
+    query["sortBy"] = `cmmstudy_${query.lang}`
+    delete query["lang"];
+
     // Create query string
     const newQuery = QueryString.stringify(query, { encodeValuesOnly: true });
 


### PR DESCRIPTION
This was caused by the search query being changed from `keywords.term[0]` to keywords[]. This commit adds a redirect on the server to rewrite this query.

This closes https://github.com/cessda/cessda.cdc.versions/issues/733