### PR TITLE
#735: Enable search for all fields, enable all advanced search cases listed in user guide

### DIFF
--- a/server/helper.ts
+++ b/server/helper.ts
@@ -311,25 +311,16 @@ function getSearchkitRouter() {
     const userQuery = req.body?.[0]?.params?.query || "";
 
     // Extract negated phrases and terms from raw user query
-    const negatedPhrasePattern = /-"([^"]+)"/g;
-    const negatedPhrases: string[] = [];
-    let match: RegExpExecArray | null;
-    while ((match = negatedPhrasePattern.exec(userQuery)) !== null) {
-      negatedPhrases.push(match[1]);
-    }
-
-    const negativeTerms: string[] = userQuery
-      .split(/\s+/)
-      .filter((term: string) => term.startsWith('-') && !term.startsWith('-"'))
-      .map((term: string) => term.slice(1));
-
-    const allExclusions = [...negatedPhrases, ...negativeTerms];
-
-    // Remove exclusions from query
+    const exclusionPattern = /-"([^"]+)"|-(\S+)/g;
+    const allExclusions: string[] = [];
     let cleanedQuery = userQuery;
-    [...negatedPhrases.map((p) => `-"${p}"`), ...negativeTerms.map((t) => `-${t}`)].forEach((exclusion) => {
-      cleanedQuery = cleanedQuery.replace(exclusion, ' ');
-    });
+
+    let match: RegExpExecArray | null;
+    while ((match = exclusionPattern.exec(userQuery)) !== null) {
+      const term = match[1] || match[2];
+      allExclusions.push(term);
+      cleanedQuery = cleanedQuery.replace(match[0], ' ');
+    }
 
     // Normalize spacing to get the final positive query
     const positiveQuery = cleanedQuery


### PR DESCRIPTION
Updated issue https://github.com/cessda/cessda.cdc.versions/issues/735 since you were right, Matthew, that the root issue was missing *. I guess I accidentally dropped it at some point while originally working on enabling more advanced searches through this beforeSearch hook.

I also hadn't added any flags here but that should mean there's too many operators enabled rather than not enough as all optional operators should be enabled by default.

I'm not sure why some of the operators don't seem to work here. I didn't notice it before since I was mainly testing + and |. I couldn't get NOT (e.g. <code>elections -presidential</code> or <code>elections + -presidential</code> to work here so I added some preprocessing that separates it into must_not. Now the examples listed in [User Guide / Advanced search](https://datacatalogue.cessda.eu/documentation/advanced-search.html) and [User Guide / Advanced search examples](https://datacatalogue.cessda.eu/documentation/advanced-search-examples.html) actually work and NOT is a bit simplified since it doesn't require using + also.

This is something that can still be looked more into later but I think this is good enough for now and fixes the main issues.

