### PR TITLE
#756: Remove samplingProcedureFreeTexts, add term to typeOfSamplingProcedures

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -42,8 +42,6 @@ export interface CMMStudy {
   typeOfModeOfCollections: TermVocabAttributes[];
   /** Keywords */
   keywords: TermVocabAttributes[];
-  /** Sampling procedure free text */
-  samplingProcedureFreeTexts: string[];
   /** Topic classifications */
   classifications: TermVocabAttributes[];
   /** Abstract */
@@ -64,7 +62,7 @@ export interface CMMStudy {
   /** Language of data files */
   fileLanguages: string[];
   /** Sampling procedure */
-  typeOfSamplingProcedures: VocabAttributes[];
+  typeOfSamplingProcedures: TermVocabAttributes[];
   /** Publisher */
   publisher: Publisher;
   /** Country */
@@ -201,7 +199,6 @@ export class MetadataUtils {
       typeOfTimeMethods: source.typeOfTimeMethods || [],
       unitTypes: source.unitTypes || [],
       typeOfSamplingProcedures: source.typeOfSamplingProcedures || [],
-      samplingProcedureFreeTexts: (source.samplingProcedureFreeTexts || []).map(text => this.stripHTMLElements(text)),
       typeOfModeOfCollections: source.typeOfModeOfCollections || [],
       dataCollectionPeriodStartdate: source.dataCollectionPeriodStartdate || '',
       dataCollectionPeriodEnddate: source.dataCollectionPeriodEnddate || '',

--- a/server/swagger-searchApiV2.ts
+++ b/server/swagger-searchApiV2.ts
@@ -393,13 +393,6 @@ export default async (client: Elasticsearch) => ({
               }
             }
           },
-          "samplingProcedureFreeTexts": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "example": "Purposive selection/case studies"
-            }
-          },
           "studyAreaCountries": {
             "type": "array",
             "items": {
@@ -472,6 +465,10 @@ export default async (client: Elasticsearch) => ({
                 },
                 "id": {
                   "type": "string"
+                },
+                "term": {
+                  "type": "string",
+                  "example": "Purposive selection/case studies"
                 }
               }
             }

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -929,17 +929,11 @@ const Detail = (props: Props) => {
                 </>
               }
 
-              {!currentThematicView.excludeFields.includes('samplingProcedureFreeTexts') &&
-                (showAllFields || item.samplingProcedureFreeTexts.length > 0) &&
+              {!currentThematicView.excludeFields.includes('typeOfSamplingProcedures') &&
+                (showAllFields || item.typeOfSamplingProcedures.length > 0) &&
                 <>
                   {generateHeading('sampProc')}
-                  {generateElements(item.samplingProcedureFreeTexts, "div",
-                    (text) => (
-                      <div
-                        dangerouslySetInnerHTML={{ __html: text }}
-                      />
-                    )
-                  )}
+                  {generateElements(item.typeOfSamplingProcedures, "div", (sampProc) => sampProc.term)}
                 </>
               }
 

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -89,9 +89,6 @@ describe('Metadata utilities', () => {
             abbr: "UKDS",
             publisher: 'UK Data Service'
           },
-          samplingProcedureFreeTexts: [
-            'Sampling Procedure<script></script>'
-          ],
           series: [],
           studyAreaCountries: [
             {
@@ -119,7 +116,14 @@ describe('Metadata utilities', () => {
               vocabUri: 'http://example.com'
             }
           ],
-          typeOfSamplingProcedures: [],
+          typeOfSamplingProcedures: [
+            {
+              id: 'UKDS1234',
+              term: 'Term',
+              vocab: 'Vocab',
+              vocabUri: 'http://example.com'
+            }
+          ],
           unitTypes: [
             {
               id: 'UKDS1234',
@@ -202,9 +206,6 @@ describe('Metadata utilities', () => {
           publisher: 'UK Data Service'
         },
         relatedPublications: [],
-        samplingProcedureFreeTexts: [
-          'Sampling Procedure'
-        ],
         series: [],
         studyAreaCountries: [
           {
@@ -224,7 +225,14 @@ describe('Metadata utilities', () => {
             vocabUri: 'http://example.com'
           }
         ],
-        typeOfSamplingProcedures: [],
+        typeOfSamplingProcedures: [
+          {
+            id: 'UKDS1234',
+            term: 'Term',
+            vocab: 'Vocab',
+            vocabUri: 'http://example.com'
+          }
+        ],
         typeOfTimeMethods: [
           {
             id: 'UKDS1234',
@@ -279,7 +287,6 @@ describe('Metadata utilities', () => {
         publicationYear: '',
         publisher: undefined,
         relatedPublications: [],
-        samplingProcedureFreeTexts: [],
         series: [],
         studyAreaCountries: [],
         studyNumber: '',
@@ -362,7 +369,6 @@ describe('Metadata utilities', () => {
             publisher:'UK Data Service'
           },
           relatedPublications: [],
-          samplingProcedureFreeTexts: [],
           series: [],
           studyAreaCountries: [
             {
@@ -390,7 +396,14 @@ describe('Metadata utilities', () => {
               vocabUri: 'http://example.com'
             }
           ],
-          typeOfSamplingProcedures: [],
+          typeOfSamplingProcedures: [
+            {
+              id: 'UKDS1234',
+              term: 'Term',
+              vocab: 'Vocab',
+              vocabUri: 'http://example.com'
+            }
+          ],
           unitTypes: [
             {
               id: 'UKDS1234',
@@ -494,7 +507,6 @@ describe('Metadata utilities', () => {
             publisher: 'UK Data Service',
           },
           relatedPublications: [],
-          samplingProcedureFreeTexts: [],
           series: [],
           studyAreaCountries: [
             {
@@ -522,7 +534,14 @@ describe('Metadata utilities', () => {
               vocabUri: 'http://example.com'
             }
           ],
-          typeOfSamplingProcedures: [],
+          typeOfSamplingProcedures: [
+            {
+              id: 'UKDS1234',
+              term: 'Term',
+              vocab: 'Vocab',
+              vocabUri: 'http://example.com'
+            }
+          ],
           unitTypes: [
             {
               id: 'UKDS1234',

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -96,10 +96,6 @@ export const mockStudy: CMMStudy = {
       publicationDate: "2001"
     }
   ],
-  samplingProcedureFreeTexts: [
-    "Sampling Procedure 1",
-    "Sampling Procedure 2"
-  ],
   series: [
     { names: ['Series 1'], uris: ['http://example.com/1'], descriptions: ["Series 1 Description"] },
     { names: ['Series 2'], uris: ['http://example.com/2'], descriptions: ["Series 2 Description"] },
@@ -133,6 +129,7 @@ export const mockStudy: CMMStudy = {
   typeOfSamplingProcedures: [
     {
       id: 'UKDS1234',
+      term: 'Term',
       vocab: 'Vocab',
       vocabUri: 'http://example.com'
     }

--- a/tests/src/components/Detail.tsx
+++ b/tests/src/components/Detail.tsx
@@ -523,7 +523,7 @@ it("should show hidden fields when 'All elements' is clicked", async () => {
     series: [],
     unitTypes: [],
     universe: undefined,
-    samplingProcedureFreeTexts: [],
+    typeOfSamplingProcedures: [],
     dataKindFreeTexts: [],
     generalDataFormats: [],
     typeOfModeOfCollections: [],


### PR DESCRIPTION
Requires recreating Elasticsearch indices with changes from https://github.com/cessda/cessda.cdc.osmh-indexer.cmm/pull/236 to work. Allows using study JSON in a more simple way when checking Sampling Procedure with FAIR tools since it's then consistent with other similar fields that usually have value from CV but not always.